### PR TITLE
Add login token handling and dashboard auth guard

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,15 +1,16 @@
-import { provideHttpClient, withFetch } from '@angular/common/http';
+import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { ApplicationConfig } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter, withEnabledBlockingInitialNavigation, withInMemoryScrolling } from '@angular/router';
 import Aura from '@primeuix/themes/aura';
 import { providePrimeNG } from 'primeng/config';
 import { appRoutes } from './app.routes';
+import { authInterceptor } from '@/services/interceptor/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
     providers: [
         provideRouter(appRoutes, withInMemoryScrolling({ anchorScrolling: 'enabled', scrollPositionRestoration: 'enabled' }), withEnabledBlockingInitialNavigation()),
-        provideHttpClient(withFetch()),
+        provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
         provideAnimationsAsync(),
         providePrimeNG({ theme: { preset: Aura, options: { darkModeSelector: '.app-dark' } } })
     ]

--- a/src/app.routes.ts
+++ b/src/app.routes.ts
@@ -3,14 +3,16 @@ import { AppLayout } from './app/layout/component/app.layout';
 import { Dashboard } from './app/pages/dashboard/dashboard';
 import { Notfound } from './app/pages/notfound/notfound';
 import { FormComplaintsComponent } from '@/pages/form-complaints/form-complaints.component';
+import { authGuard } from '@/guards/auth.guard';
 
 export const appRoutes: Routes = [
     { path: '', component: FormComplaintsComponent },
     {
-        path: 'private',
+        path: '',
         component: AppLayout,
+        canActivate: [authGuard],
         children: [
-            { path: 'private', component: Dashboard },
+            { path: 'dashboard', component: Dashboard },
             { path: 'uikit', loadChildren: () => import('./app/pages/uikit/uikit.routes') },
             { path: 'pages', loadChildren: () => import('./app/pages/pages.routes') }
         ]

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,0 +1,12 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '@/services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+    const auth = inject(AuthService);
+    const router = inject(Router);
+    if (auth.isAuthenticated()) {
+        return true;
+    }
+    return router.parseUrl('/auth/login');
+};

--- a/src/app/layout/component/app.menu.ts
+++ b/src/app/layout/component/app.menu.ts
@@ -22,7 +22,7 @@ export class AppMenu {
         this.model = [
             {
                 label: 'Home',
-                items: [{ label: 'Dashboard', icon: 'pi pi-fw pi-home', routerLink: ['/'] }]
+                items: [{ label: 'Dashboard', icon: 'pi pi-fw pi-home', routerLink: ['/dashboard'] }]
             },
             {
                 label: 'UI Components',

--- a/src/app/pages/auth/access.ts
+++ b/src/app/pages/auth/access.ts
@@ -21,7 +21,7 @@ import { AppFloatingConfigurator } from '../../layout/component/app.floatingconf
                             <span class="text-muted-color mb-8">You do not have the necessary permisions. Please contact admins.</span>
                             <img src="https://primefaces.org/cdn/templates/sakai/auth/asset-access.svg" alt="Access denied" class="mb-8" width="80%" />
                             <div class="col-span-12 mt-8 text-center">
-                                <p-button label="Go to Dashboard" routerLink="/" severity="warn" />
+                                <p-button label="Go to Dashboard" routerLink="/dashboard" severity="warn" />
                             </div>
                         </div>
                     </div>

--- a/src/app/pages/auth/error.ts
+++ b/src/app/pages/auth/error.ts
@@ -21,7 +21,7 @@ import { AppFloatingConfigurator } from '../../layout/component/app.floatingconf
                             <span class="text-muted-color mb-8">Requested resource is not available.</span>
                             <img src="https://primefaces.org/cdn/templates/sakai/auth/asset-error.svg" alt="Error" class="mb-8" width="80%" />
                             <div class="col-span-12 mt-8 text-center">
-                                <p-button label="Go to Dashboard" routerLink="/" severity="danger" />
+                                <p-button label="Go to Dashboard" routerLink="/dashboard" severity="danger" />
                             </div>
                         </div>
                     </div>

--- a/src/app/pages/auth/interfaces/login-response.ts
+++ b/src/app/pages/auth/interfaces/login-response.ts
@@ -1,0 +1,3 @@
+export interface LoginResponse {
+    access_token: string;
+}

--- a/src/app/pages/auth/login.ts
+++ b/src/app/pages/auth/login.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';
 import { InputTextModule } from 'primeng/inputtext';
 import { PasswordModule } from 'primeng/password';
 import { RippleModule } from 'primeng/ripple';
 import { AppFloatingConfigurator } from '../../layout/component/app.floatingconfigurator';
+import { AuthService } from '@/services/auth.service';
 
 @Component({
     selector: 'app-login',
@@ -50,7 +51,7 @@ import { AppFloatingConfigurator } from '../../layout/component/app.floatingconf
                             <div class="flex items-center justify-between mt-2 mb-8 gap-8">
                                 <span class="font-medium no-underline ml-2 text-right cursor-pointer text-primary">Olvidaste tu clave?</span>
                             </div>
-                            <p-button label="Ingresar" styleClass="w-full" routerLink="/"></p-button>
+                            <p-button label="Ingresar" styleClass="w-full" (click)="login()"></p-button>
                         </div>
                     </div>
                 </div>
@@ -64,4 +65,13 @@ export class Login {
     password: string = '';
 
     checked: boolean = false;
+
+    constructor(private auth: AuthService, private router: Router) {}
+
+    login() {
+        const success = this.auth.login(this.email, this.password);
+        if (success) {
+            this.router.navigate(['/dashboard']);
+        }
+    }
 }

--- a/src/app/pages/auth/login.ts
+++ b/src/app/pages/auth/login.ts
@@ -66,12 +66,12 @@ export class Login {
 
     checked: boolean = false;
 
-    constructor(private auth: AuthService, private router: Router) {}
+    constructor(private auth: AuthService, private router: Router) { }
 
     login() {
-        const success = this.auth.login(this.email, this.password);
-        if (success) {
-            this.router.navigate(['/dashboard']);
-        }
+        this.auth.login(this.email, this.password).subscribe({
+            next: () => this.router.navigateByUrl('/dashboard'),
+            error: (err) => console.error('Login error:', err)
+        });
     }
 }

--- a/src/app/pages/notfound/notfound.ts
+++ b/src/app/pages/notfound/notfound.ts
@@ -32,7 +32,7 @@ import { AppFloatingConfigurator } from '../../layout/component/app.floatingconf
                         <span class="text-primary font-bold text-3xl">404</span>
                         <h1 class="text-surface-900 dark:text-surface-0 font-bold text-3xl lg:text-5xl mb-2">Not Found</h1>
                         <div class="text-surface-600 dark:text-surface-200 mb-8">Requested resource is not available.</div>
-                        <a routerLink="/" class="w-full flex items-center py-8 border-surface-300 dark:border-surface-500 border-b">
+                        <a routerLink="/dashboard" class="w-full flex items-center py-8 border-surface-300 dark:border-surface-500 border-b">
                             <span class="flex justify-center items-center border-2 border-primary text-primary rounded-border" style="height: 3.5rem; width: 3.5rem">
                                 <i class="pi pi-fw pi-table text-2xl!"></i>
                             </span>
@@ -41,7 +41,7 @@ import { AppFloatingConfigurator } from '../../layout/component/app.floatingconf
                                 <span class="text-surface-600 dark:text-surface-200 lg:text-xl">Ultricies mi quis hendrerit dolor.</span>
                             </span>
                         </a>
-                        <a routerLink="/" class="w-full flex items-center py-8 border-surface-300 dark:border-surface-500 border-b">
+                        <a routerLink="/dashboard" class="w-full flex items-center py-8 border-surface-300 dark:border-surface-500 border-b">
                             <span class="flex justify-center items-center border-2 border-primary text-primary rounded-border" style="height: 3.5rem; width: 3.5rem">
                                 <i class="pi pi-fw pi-question-circle text-2xl!"></i>
                             </span>
@@ -50,7 +50,7 @@ import { AppFloatingConfigurator } from '../../layout/component/app.floatingconf
                                 <span class="text-surface-600 dark:text-surface-200 lg:text-xl">Phasellus faucibus scelerisque eleifend.</span>
                             </span>
                         </a>
-                        <a routerLink="/" class="w-full flex items-center mb-8 py-8 border-surface-300 dark:border-surface-500 border-b">
+                        <a routerLink="/dashboard" class="w-full flex items-center mb-8 py-8 border-surface-300 dark:border-surface-500 border-b">
                             <span class="flex justify-center items-center border-2 border-primary text-primary rounded-border" style="height: 3.5rem; width: 3.5rem">
                                 <i class="pi pi-fw pi-unlock text-2xl!"></i>
                             </span>
@@ -59,7 +59,7 @@ import { AppFloatingConfigurator } from '../../layout/component/app.floatingconf
                                 <span class="text-surface-600 dark:text-surface-200 lg:text-xl">Accumsan in nisl nisi scelerisque</span>
                             </span>
                         </a>
-                        <p-button label="Go to Dashboard" routerLink="/" />
+                        <p-button label="Go to Dashboard" routerLink="/dashboard" />
                     </div>
                 </div>
             </div>

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,11 +1,29 @@
-import { Injectable } from '@angular/core';
+import { LoginResponse } from '@/pages/auth/interfaces/login-response';
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map, tap } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-    login(email: string, password: string): boolean {
-        const token = 'mock-token';
-        localStorage.setItem('token', token);
-        return true;
+
+    private http = inject(HttpClient);
+
+    backendUrl = environment.backendUrl;
+
+    login(email: string, password: string): Observable<boolean> {
+
+        if (!email || !password) throw new Error('Email and password are required.');
+
+        let loginUrl = `${this.backendUrl}/auth/login`;
+
+        console.log(`Attempting to login with URL: ${loginUrl} and credentials: ${email}, ${password}`);
+
+
+        return this.http.post<LoginResponse>(loginUrl, { email, password }).pipe(
+            tap(res => localStorage.setItem('token', res.access_token)),
+            map(() => true)
+        );
     }
 
     logout(): void {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+    login(email: string, password: string): boolean {
+        const token = 'mock-token';
+        localStorage.setItem('token', token);
+        return true;
+    }
+
+    logout(): void {
+        localStorage.removeItem('token');
+    }
+
+    isAuthenticated(): boolean {
+        return !!localStorage.getItem('token');
+    }
+}

--- a/src/app/services/interceptor/auth.interceptor.ts
+++ b/src/app/services/interceptor/auth.interceptor.ts
@@ -1,0 +1,12 @@
+// src/app/core/interceptors/auth.interceptor.ts
+import { HttpInterceptorFn } from '@angular/common/http';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const token = localStorage.getItem('token');
+  if (!token) return next(req);
+
+  const authReq = req.clone({
+    setHeaders: { Authorization: `Bearer ${token}` }
+  });
+  return next(authReq);
+};

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,5 @@
 export const environment = {
     production: false,
+    backendUrl: 'http://localhost:3000',
     googleMapsApiKey: 'AIzaSyCYk6P2-xjdbZcUQI15gPCUsKUhnrkjXSs'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,1 +1,5 @@
-export const environment = {};
+export const environment = {
+    production: true,
+    backendUrl: 'http://localhost:3000',
+    googleMapsApiKey: 'AIzaSyCYk6P2-xjdbZcUQI15gPCUsKUhnrkjXSs'
+};


### PR DESCRIPTION
## Summary
- Save login token in localStorage and navigate to dashboard
- Add auth service and guard to protect dashboard routes
- Update navigation menu and dashboard links

## Testing
- `npm test` (fails: No inputs were found in config file)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3feed1940832b9d8a98b002cb2369