### PR TITLE
feat: add reactive complaint form

### DIFF
--- a/src/app/pages/form-complaints/form-complaints.component.html
+++ b/src/app/pages/form-complaints/form-complaints.component.html
@@ -5,56 +5,101 @@
 
         <p-fluid class="flex-1 overflow-auto">
             <div class="flex mt-8">
-                <div class="card flex flex-col gap-6 w-full">
+                <form [formGroup]="complaintForm" (ngSubmit)="onSubmit()" class="card flex flex-col gap-6 w-full">
                     <div class="font-semibold text-xl">Denuncias, Quejas o Sugerencias</div>
                     <div class="flex flex-col md:flex-row gap-6">
                         <div class="flex flex-wrap gap-2 w-full">
                             <label for="firstname">Nombres</label>
-                            <input pInputText id="firstname" type="text" />
+                            <input pInputText id="firstname" type="text" formControlName="firstName" />
+                            <small class="p-error" *ngIf="complaintForm.get('firstName')?.invalid && (complaintForm.get('firstName')?.touched || submitted)">
+                                El nombre es obligatorio
+                            </small>
                         </div>
                         <div class="flex flex-wrap gap-2 w-full">
                             <label for="lastname">Apellidos</label>
-                            <input pInputText id="lastname" type="text" />
+                            <input pInputText id="lastname" type="text" formControlName="lastName" />
+                            <small class="p-error" *ngIf="complaintForm.get('lastName')?.invalid && (complaintForm.get('lastName')?.touched || submitted)">
+                                El apellido es obligatorio
+                            </small>
                         </div>
                     </div>
                     <div class="flex flex-col md:flex-row gap-6">
                         <div class="flex flex-wrap gap-2 w-full">
                             <label for="email">Email</label>
-                            <input pInputText id="email" type="text" />
+                            <input pInputText id="email" type="text" formControlName="email" />
+                            <small class="p-error" *ngIf="complaintForm.get('email')?.errors?.['required'] && (complaintForm.get('email')?.touched || submitted)">
+                                El email es obligatorio
+                            </small>
+                            <small class="p-error" *ngIf="complaintForm.get('email')?.errors?.['email'] && (complaintForm.get('email')?.touched || submitted)">
+                                Email inválido
+                            </small>
                         </div>
                         <div class="flex flex-wrap gap-2 w-full">
                             <label for="phone">Teléfono</label>
-                            <input pInputText id="phone" type="text" />
+                            <input pInputText id="phone" type="text" formControlName="phone" />
+                            <small class="p-error" *ngIf="complaintForm.get('phone')?.invalid && (complaintForm.get('phone')?.touched || submitted)">
+                                El teléfono es obligatorio
+                            </small>
                         </div>
                     </div>
 
                     <div class="flex flex-col md:flex-row gap-6">
                         <div class="flex flex-wrap gap-2 w-full">
-                            <label for="state">Tipo</label>
-                            <p-select id="state" [(ngModel)]="dropdownItem" [options]="dropdownItems" optionLabel="name"
-                                placeholder="Seleccione uno" class="w-full"></p-select>
+                            <label for="type">Tipo</label>
+                            <p-select id="type" formControlName="type" [options]="dropdownItems" optionLabel="name"
+                                optionValue="code" placeholder="Seleccione uno" class="w-full"></p-select>
+                            <small class="p-error" *ngIf="complaintForm.get('type')?.invalid && (complaintForm.get('type')?.touched || submitted)">
+                                El tipo es obligatorio
+                            </small>
                         </div>
 
-
                         <div class="flex items-center flex-wrap gap-2 w-full">
-                            <p-checkbox id="checkOption3" name="option" value="true" [(ngModel)]="checkboxValue" />
-                            <label for="checkOption3" class="ml-2">Contactar</label>
+                            <p-checkbox id="contacted" binary="true" formControlName="contacted"></p-checkbox>
+                            <label for="contacted" class="ml-2">Contactar</label>
+                            <small class="p-error" *ngIf="complaintForm.get('contacted')?.invalid && (complaintForm.get('contacted')?.touched || submitted)">
+                                Debe aceptar ser contactado
+                            </small>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col md:flex-row gap-6">
+                        <div class="flex flex-wrap gap-2 w-full">
+                            <label for="latitude">Latitud</label>
+                            <input pInputText id="latitude" type="text" formControlName="latitude" readonly />
+                            <small class="p-error" *ngIf="complaintForm.get('latitude')?.invalid && submitted">
+                                La latitud es obligatoria
+                            </small>
+                        </div>
+                        <div class="flex flex-wrap gap-2 w-full">
+                            <label for="longitude">Longitud</label>
+                            <input pInputText id="longitude" type="text" formControlName="longitude" readonly />
+                            <small class="p-error" *ngIf="complaintForm.get('longitude')?.invalid && submitted">
+                                La longitud es obligatoria
+                            </small>
                         </div>
                     </div>
 
                     <div class="flex flex-wrap">
                         <label for="description">Descripción</label>
-                        <textarea pTextarea id="description" rows="4"></textarea>
+                        <textarea pTextarea id="description" rows="4" formControlName="description"></textarea>
+                        <small class="p-error" *ngIf="complaintForm.get('description')?.invalid && (complaintForm.get('description')?.touched || submitted)">
+                            La descripción es obligatoria
+                        </small>
                     </div>
 
-
-                    <!--div class="flex flex-wrap">
-                        <google-map class="full-map" [center]="center" [zoom]="zoom">
+                    <div class="flex flex-wrap">
+                        <google-map class="full-map" [center]="center" [zoom]="zoom" (mapClick)="setMarker($event)">
+                            <map-marker *ngIf="selectedPosition" [position]="selectedPosition"></map-marker>
                         </google-map>
-                    </div-->
-                </div>
+                    </div>
+
+                    <div class="flex justify-end">
+                        <button pButton type="submit" label="Enviar"></button>
+                    </div>
+                </form>
             </div>
         </p-fluid>
+        <p-toast></p-toast>
 
     </div>
 </div>

--- a/src/app/pages/form-complaints/form-complaints.component.html
+++ b/src/app/pages/form-complaints/form-complaints.component.html
@@ -1,105 +1,117 @@
 <div class="bg-surface-0 dark:bg-surface-900 min-h-screen">
-    <div id="home" class="landing-wrapper overflow-hidden">
-        <topbar-widget
-            class="py-6 px-6 mx-0 md:mx-12 lg:mx-20 lg:px-20 flex items-center justify-between relative lg:static" />
+    <topbar-widget
+        class="py-6 px-6 mx-0 md:mx-12 lg:mx-20 lg:px-20 flex items-center justify-between relative lg:static" />
 
-        <p-fluid class="flex-1 overflow-auto">
-            <div class="flex mt-8">
-                <form [formGroup]="complaintForm" (ngSubmit)="onSubmit()" class="card flex flex-col gap-6 w-full">
-                    <div class="font-semibold text-xl">Denuncias, Quejas o Sugerencias</div>
-                    <div class="flex flex-col md:flex-row gap-6">
-                        <div class="flex flex-wrap gap-2 w-full">
-                            <label for="firstname">Nombres</label>
-                            <input pInputText id="firstname" type="text" formControlName="firstName" />
-                            <small class="p-error" *ngIf="complaintForm.get('firstName')?.invalid && (complaintForm.get('firstName')?.touched || submitted)">
-                                El nombre es obligatorio
-                            </small>
-                        </div>
-                        <div class="flex flex-wrap gap-2 w-full">
-                            <label for="lastname">Apellidos</label>
-                            <input pInputText id="lastname" type="text" formControlName="lastName" />
-                            <small class="p-error" *ngIf="complaintForm.get('lastName')?.invalid && (complaintForm.get('lastName')?.touched || submitted)">
-                                El apellido es obligatorio
-                            </small>
-                        </div>
-                    </div>
-                    <div class="flex flex-col md:flex-row gap-6">
-                        <div class="flex flex-wrap gap-2 w-full">
-                            <label for="email">Email</label>
-                            <input pInputText id="email" type="text" formControlName="email" />
-                            <small class="p-error" *ngIf="complaintForm.get('email')?.errors?.['required'] && (complaintForm.get('email')?.touched || submitted)">
-                                El email es obligatorio
-                            </small>
-                            <small class="p-error" *ngIf="complaintForm.get('email')?.errors?.['email'] && (complaintForm.get('email')?.touched || submitted)">
-                                Email inválido
-                            </small>
-                        </div>
-                        <div class="flex flex-wrap gap-2 w-full">
-                            <label for="phone">Teléfono</label>
-                            <input pInputText id="phone" type="text" formControlName="phone" />
-                            <small class="p-error" *ngIf="complaintForm.get('phone')?.invalid && (complaintForm.get('phone')?.touched || submitted)">
-                                El teléfono es obligatorio
-                            </small>
-                        </div>
-                    </div>
+    <div class="page">
 
-                    <div class="flex flex-col md:flex-row gap-6">
-                        <div class="flex flex-wrap gap-2 w-full">
-                            <label for="type">Tipo</label>
-                            <p-select id="type" formControlName="type" [options]="dropdownItems" optionLabel="name"
-                                optionValue="code" placeholder="Seleccione uno" class="w-full"></p-select>
-                            <small class="p-error" *ngIf="complaintForm.get('type')?.invalid && (complaintForm.get('type')?.touched || submitted)">
-                                El tipo es obligatorio
-                            </small>
-                        </div>
+        <div class="card">
+            <h2 class="title">Denuncias, Quejas o Sugerencias</h2>
 
-                        <div class="flex items-center flex-wrap gap-2 w-full">
-                            <p-checkbox id="contacted" binary="true" formControlName="contacted"></p-checkbox>
-                            <label for="contacted" class="ml-2">Contactar</label>
-                            <small class="p-error" *ngIf="complaintForm.get('contacted')?.invalid && (complaintForm.get('contacted')?.touched || submitted)">
-                                Debe aceptar ser contactado
-                            </small>
-                        </div>
-                    </div>
+            <!-- Acciones -->
+            <div class="row between center mb-3">
+                <small class="muted">Puedes hacer clic en el mapa o usar tu ubicación.</small>
+                <button pButton type="button" label="Usar mi ubicación" icon="pi pi-compass"
+                    (click)="requestUserLocation()"></button>
+            </div>
 
-                    <div class="flex flex-col md:flex-row gap-6">
-                        <div class="flex flex-wrap gap-2 w-full">
-                            <label for="latitude">Latitud</label>
-                            <input pInputText id="latitude" type="text" formControlName="latitude" readonly />
-                            <small class="p-error" *ngIf="complaintForm.get('latitude')?.invalid && submitted">
-                                La latitud es obligatoria
-                            </small>
-                        </div>
-                        <div class="flex flex-wrap gap-2 w-full">
-                            <label for="longitude">Longitud</label>
-                            <input pInputText id="longitude" type="text" formControlName="longitude" readonly />
-                            <small class="p-error" *ngIf="complaintForm.get('longitude')?.invalid && submitted">
-                                La longitud es obligatoria
-                            </small>
-                        </div>
-                    </div>
-
-                    <div class="flex flex-wrap">
-                        <label for="description">Descripción</label>
-                        <textarea pTextarea id="description" rows="4" formControlName="description"></textarea>
-                        <small class="p-error" *ngIf="complaintForm.get('description')?.invalid && (complaintForm.get('description')?.touched || submitted)">
-                            La descripción es obligatoria
-                        </small>
-                    </div>
-
-                    <div class="flex flex-wrap">
-                        <google-map class="full-map" [center]="center" [zoom]="zoom" (mapClick)="setMarker($event)">
+            <!-- Layout responsive: en móvil apila, en desktop 2 columnas -->
+            <div class="grid gap-3">
+                <!-- Columna mapa -->
+                <div class="col-12 md:col-6">
+                    <div class="map">
+                        <google-map [center]="center || { lat: -0.1807, lng: -78.4678 }" [zoom]="zoom"
+                            (mapClick)="setMarker($event)">
                             <map-marker *ngIf="selectedPosition" [position]="selectedPosition"></map-marker>
                         </google-map>
                     </div>
+                </div>
 
-                    <div class="flex justify-end">
-                        <button pButton type="submit" label="Enviar"></button>
-                    </div>
-                </form>
+                <!-- Columna formulario -->
+                <div class="col-12 md:col-6">
+                    <form [formGroup]="complaintForm" (ngSubmit)="onSubmit()" class="form">
+                        <div class="grid gap-2">
+                            <div class="col-12 md:col-6">
+                                <label for="firstName">Nombres</label>
+                                <input pInputText id="firstName" formControlName="firstName" />
+                                <small class="p-error"
+                                    *ngIf="submitted && complaintForm.get('firstName')?.invalid">Campo
+                                    requerido</small>
+                            </div>
+
+                            <div class="col-12 md:col-6">
+                                <label for="lastName">Apellidos</label>
+                                <input pInputText id="lastName" formControlName="lastName" />
+                                <small class="p-error" *ngIf="submitted && complaintForm.get('lastName')?.invalid">Campo
+                                    requerido</small>
+                            </div>
+
+                            <div class="col-12 md:col-6">
+                                <label for="email">Correo</label>
+                                <input pInputText id="email" type="email" placeholder="tucorreo@dominio.com"
+                                    formControlName="email" />
+                                <small class="p-error"
+                                    *ngIf="submitted && complaintForm.get('email')?.hasError('required')">Campo
+                                    requerido</small>
+                                <small class="p-error"
+                                    *ngIf="submitted && complaintForm.get('email')?.hasError('email')">Correo
+                                    inválido</small>
+                            </div>
+
+                            <div class="col-12 md:col-6">
+                                <label for="phone">Teléfono</label>
+                                <input pInputText id="phone" formControlName="phone" />
+                                <small class="p-error" *ngIf="submitted && complaintForm.get('phone')?.invalid">Campo
+                                    requerido</small>
+                            </div>
+
+                            <div class="col-12">
+                                <label for="type">Tipo</label>
+                                <p-select id="type" formControlName="type" [options]="dropdownItems" optionLabel="name"
+                                    optionValue="code" placeholder="Selecciona un tipo"></p-select>
+                                <small class="p-error" *ngIf="submitted && complaintForm.get('type')?.invalid">Campo
+                                    requerido</small>
+                            </div>
+
+                            <div class="col-12">
+                                <label for="description">Descripción</label>
+                                <textarea pTextarea id="description" formControlName="description" rows="6"
+                                    [autoResize]="true"></textarea>
+                                <small class="p-error"
+                                    *ngIf="submitted && complaintForm.get('description')?.invalid">Campo
+                                    requerido</small>
+                            </div>
+
+                            <div class="col-12">
+                                <p-checkbox inputId="contacted" binary="true" formControlName="contacted"
+                                    label="Acepto ser contactado para dar seguimiento"></p-checkbox>
+                                <small class="p-error block"
+                                    *ngIf="submitted && (complaintForm.get('contacted')?.hasError('requiredTrue'))">
+                                    Debes aceptar el contacto
+                                </small>
+                            </div>
+
+                            <!-- Coordenadas solo lectura (ocúltalas si no quieres mostrarlas) -->
+                            <div class="col-12 md:col-6">
+                                <label for="latitude">Latitud</label>
+                                <input pInputText id="latitude" formControlName="latitude" readonly />
+                            </div>
+                            <div class="col-12 md:col-6">
+                                <label for="longitude">Longitud</label>
+                                <input pInputText id="longitude" formControlName="longitude" readonly />
+                            </div>
+                        </div>
+
+                        <div class="row end mt-3">
+                            <button pButton type="submit" label="Enviar" icon="pi pi-send"
+                                class="p-button-rounded"></button>
+                        </div>
+                    </form>
+                </div>
             </div>
-        </p-fluid>
-        <p-toast></p-toast>
+        </div>
 
+        <p-toast></p-toast>
     </div>
+
+
 </div>

--- a/src/app/pages/form-complaints/form-complaints.component.scss
+++ b/src/app/pages/form-complaints/form-complaints.component.scss
@@ -1,4 +1,101 @@
-.full-map {
-  width: 100% !important;
-  height: 500px;
+.p-error{
+    color: red;
 }
+/* --- Fixes generales para móvil --- */
+:host {
+  display: block;
+  /* Evita scroll horizontal del componente en móvil */
+  overflow-x: hidden;
+}
+
+/* Asegura que padding + border se midan dentro del ancho */
+*, *::before, *::after { box-sizing: border-box; }
+
+/* Página y tarjeta: sin desbordes laterales */
+.page {
+  width: 100%;
+  overflow-x: hidden;            /* clave para cortar cualquier spill */
+  padding-inline: 12px;          /* un poco de respiro en móvil */
+}
+
+.card {
+  width: 100%;
+  max-width: 1200px;          /* más ancho que antes */
+  background: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  border-radius: 16px;
+  padding: 2rem;              /* más aire */
+  margin: 2rem auto;
+  box-shadow: 0 8px 24px rgba(0,0,0,.08); /* sombra más marcada */
+  transition: box-shadow .3s ease;
+}
+.card:hover {
+  box-shadow: 0 12px 32px rgba(0,0,0,.12); /* efecto ligero al pasar el mouse */
+}
+
+/* Grid: define 1 columna en móvil para que nada empuje el ancho */
+.grid { display: grid; grid-template-columns: 1fr; }
+.col-12 { grid-column: 1 / -1; min-width: 0; }  /* min-width:0 evita overflow dentro de grid */
+
+/* En >=768px volvemos a 12 columnas y 2 col de 6 */
+@media (min-width: 768px) {
+  .grid { grid-template-columns: repeat(12, 1fr); }
+  .md\:col-6 { grid-column: span 6; min-width: 0; }
+}
+
+/* Fila del botón: que pueda partir línea si no cabe */
+.row { display: flex; gap: .75rem; align-items: center; }
+.between { justify-content: space-between; flex-wrap: wrap; }
+
+/* Botón: que no obligue un ancho mayor al viewport */
+:host ::ng-deep .p-button {
+  border-radius: 9999px;
+  max-width: 100%;
+  white-space: nowrap;           /* mantiene etiqueta, pero… */
+}
+
+/* Layout desktop: formulario más ancho que el mapa */
+@media (min-width: 992px) {
+  .grid {
+    grid-template-columns: repeat(12, 1fr);
+    gap: 2rem;
+  }
+  .col-12.md\:col-6:first-child { grid-column: span 5; }  /* mapa */
+  .col-12.md\:col-6:last-child  { grid-column: span 7; }  /* formulario */
+}
+
+/* En pantallas estrechas, deja el botón a 100% para evitar overflow */
+@media (max-width: 420px) {
+  :host ::ng-deep .p-button { width: 100%; }
+}
+
+/* Mapa: que no empuje el ancho y siempre se recorte dentro de su contenedor */
+.map {
+  width: 100%;
+  height: 420px;
+  border: 1px solid var(--surface-border);
+  border-radius: 10px;
+  overflow: hidden;              /* recorta controles del mapa si se salen */
+  min-width: 0;                  /* importante para grid/flex */
+  google-map { display: block; width: 100%; height: 100%; }
+}
+@media (min-width: 992px) { .map { height: 500px; } }
+
+/* Inputs, selects, textarea a 100% */
+:host ::ng-deep .p-inputtext,
+:host ::ng-deep .p-textarea,
+:host ::ng-deep .p-dropdown { width: 100%; }
+
+/* Tipografía de errores */
+:host ::ng-deep .p-error { font-size: .8rem; }
+
+/* Título y cabecera más compactos en móvil */
+.title {
+  margin: 0 0 1.5rem 0;
+  font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+  font-weight: 700;
+  color: var(--text-color);
+}
+.muted { opacity: .75; }
+
+

--- a/src/app/pages/form-complaints/form-complaints.component.ts
+++ b/src/app/pages/form-complaints/form-complaints.component.ts
@@ -15,10 +15,12 @@ import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angula
 import { ComplaintsService } from '../service/complaints.service';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
+import { CommonModule } from '@angular/common';
 
 @Component({
     selector: 'app-form-complaints',
     imports: [
+        CommonModule,
         RouterModule,
         TopbarWidget,
         RippleModule,
@@ -44,8 +46,8 @@ export class FormComplaintsComponent implements OnInit {
     complaintForm!: FormGroup;
     submitted = false;
 
-    center: google.maps.LatLngLiteral = { lat: 40.73061, lng: -73.935242 };
-    zoom = 10;
+    center: google.maps.LatLngLiteral = null!;
+    zoom = 20;
     selectedPosition: google.maps.LatLngLiteral | null = null;
 
     dropdownItems = [
@@ -58,7 +60,7 @@ export class FormComplaintsComponent implements OnInit {
         private fb: FormBuilder,
         private complaintsService: ComplaintsService,
         private messageService: MessageService
-    ) {}
+    ) { }
 
     ngOnInit() {
         this.complaintForm = this.fb.group({
@@ -75,20 +77,66 @@ export class FormComplaintsComponent implements OnInit {
     }
 
     setMarker(event: google.maps.MapMouseEvent) {
-        if (event.latLng) {
-            this.selectedPosition = {
-                lat: event.latLng.lat(),
-                lng: event.latLng.lng()
-            };
-            this.complaintForm.patchValue({
-                latitude: this.selectedPosition.lat,
-                longitude: this.selectedPosition.lng
-            });
-        }
+        if (!event.latLng) return;
+        this.selectedPosition = { lat: event.latLng.lat(), lng: event.latLng.lng() };
+        this.complaintForm.patchValue({
+            latitude: this.selectedPosition.lat,
+            longitude: this.selectedPosition.lng
+        });
     }
+
+    requestUserLocation() {
+        if (!('geolocation' in navigator)) {
+            this.messageService.add({
+                severity: 'error',
+                summary: 'Geolocalización no soportada',
+                detail: 'Tu navegador no soporta geolocalización.'
+            });
+            return;
+        }
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                const { latitude, longitude } = position.coords;
+                this.center = { lat: latitude, lng: longitude };
+                this.zoom = 20;
+                this.selectedPosition = { lat: latitude, lng: longitude };
+                this.complaintForm.patchValue({ latitude, longitude });
+
+                this.messageService.add({
+                    severity: 'success',
+                    summary: 'Ubicación obtenida',
+                    detail: 'Puedes mover el marcador para ajustar el punto.'
+                });
+            },
+            (error) => {
+                let detail = 'No se pudo obtener la ubicación del dispositivo.';
+                if (error.code === error.PERMISSION_DENIED) {
+                    detail = 'Permiso denegado. Selecciona un punto en el mapa.';
+                }
+                this.messageService.add({
+                    severity: 'warn',
+                    summary: 'Ubicación no disponible',
+                    detail
+                });
+            },
+            { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+        );
+    }
+
 
     onSubmit() {
         this.submitted = true;
+
+        if (!this.complaintForm.value.latitude || !this.complaintForm.value.longitude) {
+            this.messageService.add({
+                severity: 'warn',
+                summary: 'Falta ubicación',
+                detail: 'Haz clic en "Usar mi ubicación" o selecciona un punto en el mapa.'
+            });
+            return;
+        }
+
         if (this.complaintForm.invalid) {
             this.complaintForm.markAllAsTouched();
             return;

--- a/src/app/pages/form-complaints/form-complaints.component.ts
+++ b/src/app/pages/form-complaints/form-complaints.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { DividerModule } from 'primeng/divider';
@@ -6,39 +6,112 @@ import { RippleModule } from 'primeng/ripple';
 import { StyleClassModule } from 'primeng/styleclass';
 import { TopbarWidget } from './components/topbarwidget.component';
 import { InputTextModule } from 'primeng/inputtext';
-import { FormsModule } from '@angular/forms';
 import { FluidModule } from 'primeng/fluid';
 import { SelectModule } from 'primeng/select';
 import { TextareaModule } from 'primeng/textarea';
 import { CheckboxModule } from 'primeng/checkbox';
 import { GoogleMapsModule } from '@angular/google-maps';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
+import { ComplaintsService } from '../service/complaints.service';
+import { MessageService } from 'primeng/api';
+import { ToastModule } from 'primeng/toast';
 
 @Component({
     selector: 'app-form-complaints',
-    imports: [RouterModule, TopbarWidget, RippleModule, StyleClassModule, ButtonModule, DividerModule, InputTextModule,
-        FluidModule, ButtonModule, SelectModule, FormsModule, TextareaModule, CheckboxModule, GoogleMapsModule],
+    imports: [
+        RouterModule,
+        TopbarWidget,
+        RippleModule,
+        StyleClassModule,
+        ButtonModule,
+        DividerModule,
+        InputTextModule,
+        FluidModule,
+        SelectModule,
+        TextareaModule,
+        CheckboxModule,
+        GoogleMapsModule,
+        ReactiveFormsModule,
+        ToastModule
+    ],
     standalone: true,
     templateUrl: './form-complaints.component.html',
-    styleUrl: './form-complaints.component.scss'
+    styleUrl: './form-complaints.component.scss',
+    providers: [ComplaintsService, MessageService]
 })
-export class FormComplaintsComponent {
+export class FormComplaintsComponent implements OnInit {
+
+    complaintForm!: FormGroup;
+    submitted = false;
 
     center: google.maps.LatLngLiteral = { lat: 40.73061, lng: -73.935242 };
     zoom = 10;
-    markers = [
-        { lat: 40.73061, lng: -73.935242 },
-        { lat: 40.74988, lng: -73.968285 }
-    ];
-
-    dropdownItem = null;
-    checkboxValue: any[] = [];
-
+    selectedPosition: google.maps.LatLngLiteral | null = null;
 
     dropdownItems = [
-        { name: 'Queja', code: 'COMPLAINT' },
-        { name: 'Denuncia', code: 'COMPLAINT' },
-        { name: 'Sugerencia', code: 'SUGGESTION' },
-        { name: 'Felicitación', code: 'COMPLIMENT' }
+        { name: 'Queja', code: 'complaint' },
+        { name: 'Sugerencia', code: 'suggestion' },
+        { name: 'Felicitación', code: 'compliment' }
     ];
 
+    constructor(
+        private fb: FormBuilder,
+        private complaintsService: ComplaintsService,
+        private messageService: MessageService
+    ) {}
+
+    ngOnInit() {
+        this.complaintForm = this.fb.group({
+            firstName: ['', Validators.required],
+            lastName: ['', Validators.required],
+            email: ['', [Validators.required, Validators.email]],
+            description: ['', Validators.required],
+            phone: ['', Validators.required],
+            type: ['', Validators.required],
+            contacted: [false, Validators.requiredTrue],
+            latitude: ['', Validators.required],
+            longitude: ['', Validators.required]
+        });
+    }
+
+    setMarker(event: google.maps.MapMouseEvent) {
+        if (event.latLng) {
+            this.selectedPosition = {
+                lat: event.latLng.lat(),
+                lng: event.latLng.lng()
+            };
+            this.complaintForm.patchValue({
+                latitude: this.selectedPosition.lat,
+                longitude: this.selectedPosition.lng
+            });
+        }
+    }
+
+    onSubmit() {
+        this.submitted = true;
+        if (this.complaintForm.invalid) {
+            this.complaintForm.markAllAsTouched();
+            return;
+        }
+
+        this.complaintsService.createComplaint(this.complaintForm.value).subscribe({
+            next: () => {
+                this.messageService.add({
+                    severity: 'success',
+                    summary: 'Éxito',
+                    detail: 'Formulario enviado correctamente'
+                });
+                this.complaintForm.reset();
+                this.submitted = false;
+                this.selectedPosition = null;
+            },
+            error: () => {
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'No se pudo enviar la información'
+                });
+            }
+        });
+    }
 }

--- a/src/app/pages/service/complaints.service.ts
+++ b/src/app/pages/service/complaints.service.ts
@@ -38,6 +38,10 @@ export class ComplaintsService {
         return this.http.get<FeedbackListResponse>(`${this.apiUrl}/private/feedback?page=1&limit=10`);
     }
 
+    createComplaint(payload: Omit<Feedback, '_id' | 'status' | 'dateRegister' | '__v'>) {
+        return this.http.post(`${this.apiUrl}/public/feedback`, payload);
+    }
+
     cancelFeedback(feedbackId: string) {
         console.log('Cancelling feedback with ID:', feedbackId);
         return this.http.delete(`${this.apiUrl}/private/feedback/${feedbackId}`);


### PR DESCRIPTION
## Summary
- implement dynamic reactive form for complaints with validation
- send complaint data to backend
- add createComplaint service method

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No inputs were found in config file '/workspace/complaints-suggestions-frontend/tsconfig.spec.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a5dc5356e8832b8ae7da8b48ba912c