### PR TITLE
feat: capture location and address from map

### DIFF
--- a/src/app/pages/form-complaints/form-complaints.component.html
+++ b/src/app/pages/form-complaints/form-complaints.component.html
@@ -1,7 +1,6 @@
 <div class="bg-surface-0 dark:bg-surface-900 min-h-screen">
     <div id="home" class="landing-wrapper overflow-hidden">
-        <topbar-widget
-            class="py-6 px-6 mx-0 md:mx-12 lg:mx-20 lg:px-20 flex items-center justify-between relative lg:static" />
+        <topbar-widget class="py-6 px-6 mx-0 md:mx-12 lg:mx-20 lg:px-20 flex items-center justify-between relative lg:static" />
 
         <p-fluid class="flex-1 overflow-auto">
             <div class="flex mt-8">
@@ -30,11 +29,31 @@
 
                     <div class="flex flex-col md:flex-row gap-6">
                         <div class="flex flex-wrap gap-2 w-full">
-                            <label for="state">Tipo</label>
-                            <p-select id="state" [(ngModel)]="dropdownItem" [options]="dropdownItems" optionLabel="name"
-                                placeholder="Seleccione uno" class="w-full"></p-select>
+                            <label for="mainStreet">Calle A</label>
+                            <input pInputText id="mainStreet" type="text" [(ngModel)]="mainStreet" />
                         </div>
+                        <div class="flex flex-wrap gap-2 w-full">
+                            <label for="crossStreet">Calle B</label>
+                            <input pInputText id="crossStreet" type="text" [(ngModel)]="crossStreet" />
+                        </div>
+                    </div>
 
+                    <div class="flex flex-col md:flex-row gap-6">
+                        <div class="flex flex-wrap gap-2 w-full">
+                            <label for="latitude">Latitud</label>
+                            <input pInputText id="latitude" type="text" [(ngModel)]="latitude" readonly />
+                        </div>
+                        <div class="flex flex-wrap gap-2 w-full">
+                            <label for="longitude">Longitud</label>
+                            <input pInputText id="longitude" type="text" [(ngModel)]="longitude" readonly />
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col md:flex-row gap-6">
+                        <div class="flex flex-wrap gap-2 w-full">
+                            <label for="state">Tipo</label>
+                            <p-select id="state" [(ngModel)]="dropdownItem" [options]="dropdownItems" optionLabel="name" placeholder="Seleccione uno" class="w-full"></p-select>
+                        </div>
 
                         <div class="flex items-center flex-wrap gap-2 w-full">
                             <p-checkbox id="checkOption3" name="option" value="true" [(ngModel)]="checkboxValue" />
@@ -46,15 +65,13 @@
                         <label for="description">Descripción</label>
                         <textarea pTextarea id="description" rows="4"></textarea>
                     </div>
-
-
-                    <!--div class="flex flex-wrap">
-                        <google-map class="full-map" [center]="center" [zoom]="zoom">
+                    <div class="flex flex-wrap">
+                        <google-map class="full-map" [center]="center" [zoom]="zoom" (mapClick)="onMapClick($event)">
+                            <map-marker *ngIf="marker" [position]="marker"></map-marker>
                         </google-map>
-                    </div-->
+                    </div>
                 </div>
             </div>
         </p-fluid>
-
     </div>
 </div>

--- a/src/app/pages/form-complaints/form-complaints.component.ts
+++ b/src/app/pages/form-complaints/form-complaints.component.ts
@@ -15,24 +15,22 @@ import { GoogleMapsModule } from '@angular/google-maps';
 
 @Component({
     selector: 'app-form-complaints',
-    imports: [RouterModule, TopbarWidget, RippleModule, StyleClassModule, ButtonModule, DividerModule, InputTextModule,
-        FluidModule, ButtonModule, SelectModule, FormsModule, TextareaModule, CheckboxModule, GoogleMapsModule],
+    imports: [RouterModule, TopbarWidget, RippleModule, StyleClassModule, ButtonModule, DividerModule, InputTextModule, FluidModule, ButtonModule, SelectModule, FormsModule, TextareaModule, CheckboxModule, GoogleMapsModule],
     standalone: true,
     templateUrl: './form-complaints.component.html',
     styleUrl: './form-complaints.component.scss'
 })
 export class FormComplaintsComponent {
-
     center: google.maps.LatLngLiteral = { lat: 40.73061, lng: -73.935242 };
     zoom = 10;
-    markers = [
-        { lat: 40.73061, lng: -73.935242 },
-        { lat: 40.74988, lng: -73.968285 }
-    ];
+    marker: google.maps.LatLngLiteral | null = null;
+    latitude: number | null = null;
+    longitude: number | null = null;
+    mainStreet = '';
+    crossStreet = '';
 
     dropdownItem = null;
     checkboxValue: any[] = [];
-
 
     dropdownItems = [
         { name: 'Queja', code: 'COMPLAINT' },
@@ -41,4 +39,20 @@ export class FormComplaintsComponent {
         { name: 'Felicitación', code: 'COMPLIMENT' }
     ];
 
+    onMapClick(event: google.maps.MapMouseEvent) {
+        if (event.latLng) {
+            this.marker = event.latLng.toJSON();
+            this.latitude = this.marker.lat;
+            this.longitude = this.marker.lng;
+
+            const geocoder = new google.maps.Geocoder();
+            geocoder.geocode({ location: this.marker }).then(({ results }) => {
+                if (results[0]) {
+                    const routes = results[0].address_components.filter((component) => component.types.includes('route'));
+                    this.mainStreet = routes[0]?.long_name ?? '';
+                    this.crossStreet = routes[1]?.long_name ?? '';
+                }
+            });
+        }
+    }
 }

--- a/src/app/pages/form-complaints/interfaces/feedback.ts
+++ b/src/app/pages/form-complaints/interfaces/feedback.ts
@@ -8,4 +8,6 @@ export interface CreateFeedback {
     contacted: boolean;
     latitude: number;
     longitude: number;
+    mainStreet: string;
+    crossStreet: string;
 }


### PR DESCRIPTION
## Summary
- add map click handler that saves coordinates and reverse geocodes street names
- show street, latitude and longitude fields bound to map selection
- extend CreateFeedback interface with street information

## Testing
- `npm test -- --watch=false` *(fails: No inputs were found in config file '/workspace/complaints-suggestions-frontend/tsconfig.spec.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a8e25144bc832b9a8254c2a38cdadf