### PR TITLE
feat: add auth token cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@primeuix/themes": "^1.2.1",
         "@tailwindcss/postcss": "^4.1.11",
         "chart.js": "4.4.2",
+        "ngx-cookie-service": "^17.0.0",
         "primeclt": "^0.1.5",
         "primeicons": "^7.0.0",
         "primeng": "^20",

--- a/src/app.routes.ts
+++ b/src/app.routes.ts
@@ -4,9 +4,11 @@ import { Dashboard } from './app/pages/dashboard/dashboard';
 import { Notfound } from './app/pages/notfound/notfound';
 import { FormComplaintsComponent } from '@/pages/form-complaints/form-complaints.component';
 import { authGuard } from '@/guards/auth.guard';
+import { Login } from './app/pages/auth/login';
 
 export const appRoutes: Routes = [
     { path: '', component: FormComplaintsComponent },
+    { path: 'login', component: Login },
     {
         path: '',
         component: AppLayout,

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -8,5 +8,5 @@ export const authGuard: CanActivateFn = () => {
     if (auth.isAuthenticated()) {
         return true;
     }
-    return router.parseUrl('/auth/login');
+    return router.parseUrl('/login');
 };

--- a/src/app/pages/auth/login.ts
+++ b/src/app/pages/auth/login.ts
@@ -66,10 +66,13 @@ export class Login {
 
     checked: boolean = false;
 
-    constructor(private auth: AuthService, private router: Router) { }
+    constructor(
+        private auth: AuthService,
+        private router: Router
+    ) {}
 
     login() {
-        this.auth.login(this.email, this.password).subscribe({
+        this.auth.login({ email: this.email, password: this.password, remember: this.checked }).subscribe({
             next: () => this.router.navigateByUrl('/dashboard'),
             error: (err) => console.error('Login error:', err)
         });

--- a/src/app/pages/form-complaints/components/topbarwidget.component.ts
+++ b/src/app/pages/form-complaints/components/topbarwidget.component.ts
@@ -3,7 +3,7 @@ import { StyleClassModule } from 'primeng/styleclass';
 import { Router, RouterModule } from '@angular/router';
 import { RippleModule } from 'primeng/ripple';
 import { ButtonModule } from 'primeng/button';
-import { AppFloatingConfigurator } from "@/layout/component/app.floatingconfigurator";
+import { AppFloatingConfigurator } from '@/layout/component/app.floatingconfigurator';
 
 @Component({
     selector: 'topbar-widget',
@@ -29,18 +29,17 @@ import { AppFloatingConfigurator } from "@/layout/component/app.floatingconfigur
             <span class="text-surface-900 dark:text-surface-0 font-medium text-2xl leading-normal mr-20"></span>
         </a>
 
-        <a pButton [text]="false" severity="secondary" [rounded]="true" pRipple class="lg:hidden!" pStyleClass="@next"
-        enterFromClass="hidden" leaveToClass="hidden" [hideOnOutsideClick]="true">
+        <a pButton [text]="false" severity="secondary" [rounded]="true" pRipple class="lg:hidden!" pStyleClass="@next" enterFromClass="hidden" leaveToClass="hidden" [hideOnOutsideClick]="true">
             <i class="pi pi-bars text-2xl!"></i>
         </a>
 
         <div class="items-center bg-surface-0 dark:bg-surface-900 grow justify-between hidden lg:flex absolute lg:static w-full left-0 top-full px-12 lg:px-0 z-20 rounded-border">
             <div class="flex border-t lg:border-t-0 border-surface py-4 lg:py-0 mt-4 lg:mt-0 gap-2 ml-auto">
-                <button pButton pRipple label="Iniciar Sesión" routerLink="/auth/login" [rounded]="true" [text]="true" ></button>
+                <button pButton pRipple label="Iniciar Sesión" routerLink="/login" [rounded]="true" [text]="true"></button>
                 <app-floating-configurator [float]="false" />
             </div>
         </div>`
 })
 export class TopbarWidget {
-    constructor(public router: Router) { }
+    constructor(public router: Router) {}
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -3,34 +3,49 @@ import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, map, tap } from 'rxjs';
 import { environment } from 'src/environments/environment';
+import { CookieService } from 'ngx-cookie-service';
+import { Router } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-
     private http = inject(HttpClient);
+    private cookies = inject(CookieService);
+    private router = inject(Router);
 
     backendUrl = environment.backendUrl;
 
-    login(email: string, password: string): Observable<boolean> {
-
+    login(credentials: { email: string; password: string; remember: boolean }): Observable<boolean> {
+        const { email, password, remember } = credentials;
         if (!email || !password) throw new Error('Email and password are required.');
 
-        let loginUrl = `${this.backendUrl}/auth/login`;
-
-        console.log(`Attempting to login with URL: ${loginUrl} and credentials: ${email}, ${password}`);
-
+        const loginUrl = `${this.backendUrl}/auth/login`;
 
         return this.http.post<LoginResponse>(loginUrl, { email, password }).pipe(
-            tap(res => localStorage.setItem('token', res.access_token)),
+            tap((res) => {
+                const secure = window.location.protocol === 'https:';
+                if (remember) {
+                    const expires = new Date();
+                    expires.setDate(expires.getDate() + 7);
+                    this.cookies.set('access_token', res.access_token, expires, '/', undefined, secure, 'Lax');
+                } else {
+                    this.cookies.set('access_token', res.access_token, undefined, '/', undefined, secure, 'Lax');
+                }
+            }),
             map(() => true)
         );
     }
 
+    getToken(): string | null {
+        const token = this.cookies.get('access_token');
+        return token ? token : null;
+    }
+
     logout(): void {
-        localStorage.removeItem('token');
+        this.cookies.delete('access_token', '/');
+        this.router.navigateByUrl('/login');
     }
 
     isAuthenticated(): boolean {
-        return !!localStorage.getItem('token');
+        return this.cookies.check('access_token');
     }
 }

--- a/src/app/services/interceptor/auth.interceptor.ts
+++ b/src/app/services/interceptor/auth.interceptor.ts
@@ -1,12 +1,27 @@
 // src/app/core/interceptors/auth.interceptor.ts
-import { HttpInterceptorFn } from '@angular/common/http';
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from '@/services/auth.service';
+import { catchError } from 'rxjs/operators';
+import { throwError } from 'rxjs';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
-  const token = localStorage.getItem('token');
-  if (!token) return next(req);
+    const auth = inject(AuthService);
+    if (!req.url.includes('/auth/login')) {
+        const token = auth.getToken();
+        if (token) {
+            req = req.clone({
+                setHeaders: { Authorization: `Bearer ${token}` }
+            });
+        }
+    }
 
-  const authReq = req.clone({
-    setHeaders: { Authorization: `Bearer ${token}` }
-  });
-  return next(authReq);
+    return next(req).pipe(
+        catchError((error: HttpErrorResponse) => {
+            if (error.status === 401) {
+                auth.logout();
+            }
+            return throwError(() => error);
+        })
+    );
 };


### PR DESCRIPTION
## Summary
- store auth token in `access_token` cookie via `AuthService` with support for session and 7-day remember option
- secure API calls using `AuthInterceptor` and handle 401 responses
- guard and login flow updated to rely on cookie-based auth and new `/login` route

## Testing
- `npm run format`
- `npm test` *(fails: No inputs were found in config file tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be50fd89ec832baeef0d80e25e803d