### PR TITLE
feat: allow attaching image in complaints form

### DIFF
--- a/src/app/pages/form-complaints/form-complaints.component.html
+++ b/src/app/pages/form-complaints/form-complaints.component.html
@@ -82,10 +82,17 @@
                             </div>
 
                             <div class="col-12">
-                                <label for="attachment">Imagen</label>
-                                <input type="file" id="attachment" (change)="onFileSelected($event)"
-                                    accept="image/*" capture />
-                            </div>
+                               <b> <label for="attachment">Imagen </label> </b> 
+                                <input type="file" id="attachment" (change)="onFileSelected($event)" accept="image/*" capture />
+                                
+                                <!-- Vista previa -->
+                                <div *ngIf="previewUrl" style="margin-top:10px;">
+                                    <img [src]="previewUrl"
+                                         alt="Vista previa"
+                                         style="max-width:100% !important; height:auto; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.2);" />
+                                  </div>
+                                  
+                              </div>
 
                             <!-- Coordenadas solo lectura (ocúltalas si no quieres mostrarlas) -->
                             <div class="col-12 md:col-12">

--- a/src/app/pages/form-complaints/form-complaints.component.html
+++ b/src/app/pages/form-complaints/form-complaints.component.html
@@ -81,6 +81,12 @@
                                     requerido</small>
                             </div>
 
+                            <div class="col-12">
+                                <label for="attachment">Imagen</label>
+                                <input type="file" id="attachment" (change)="onFileSelected($event)"
+                                    accept="image/*" capture />
+                            </div>
+
                             <!-- Coordenadas solo lectura (ocúltalas si no quieres mostrarlas) -->
                             <div class="col-12 md:col-12">
                                 <label for="address">Dirección</label>

--- a/src/app/pages/form-complaints/form-complaints.component.ts
+++ b/src/app/pages/form-complaints/form-complaints.component.ts
@@ -83,6 +83,7 @@ export class FormComplaintsComponent implements OnInit {
             lastName: ['', Validators.required],
             email: ['', [Validators.required, Validators.email]],
             description: ['', Validators.required],
+            attachment: [null],
             phone: ['', Validators.required],
             type: ['', Validators.required],
             contacted: [true, Validators.requiredTrue],
@@ -152,6 +153,15 @@ export class FormComplaintsComponent implements OnInit {
                 streetB
             });
         });
+    }
+
+    onFileSelected(event: Event) {
+        const input = event.target as HTMLInputElement;
+        const file = input.files && input.files.length ? input.files[0] : null;
+        if (file) {
+            this.complaintForm.patchValue({ attachment: file });
+            this.complaintForm.get('attachment')?.updateValueAndValidity();
+        }
     }
 
     private getCurrentPositionOnce(timeout = 10000): Promise<GeolocationPosition> {
@@ -283,7 +293,15 @@ export class FormComplaintsComponent implements OnInit {
 
         console.log("enviando formulario3");
 
-        this.complaintsService.createComplaint(this.complaintForm.value).subscribe({
+        const formData = new FormData();
+        Object.keys(this.complaintForm.controls).forEach(key => {
+            const value = this.complaintForm.get(key)?.value;
+            if (value !== null && value !== undefined) {
+                formData.append(key, value instanceof Blob ? value : String(value));
+            }
+        });
+
+        this.complaintsService.createComplaint(formData).subscribe({
             next: () => {
                 this.messageService.add({
                     severity: 'success',

--- a/src/app/pages/form-complaints/form-complaints.component.ts
+++ b/src/app/pages/form-complaints/form-complaints.component.ts
@@ -44,6 +44,8 @@ import { GeocodingService } from '../service/geocoding.service';
 })
 export class FormComplaintsComponent implements OnInit {
 
+    previewUrl: string | null = null;
+
     complaintForm!: FormGroup;
     submitted = false;
 
@@ -159,10 +161,15 @@ export class FormComplaintsComponent implements OnInit {
         const input = event.target as HTMLInputElement;
         const file = input.files && input.files.length ? input.files[0] : null;
         if (file) {
-            this.complaintForm.patchValue({ attachment: file });
-            this.complaintForm.get('attachment')?.updateValueAndValidity();
+          // setea el archivo en el form
+          this.complaintForm.patchValue({ attachment: file });
+          this.complaintForm.get('attachment')?.updateValueAndValidity();
+      
+          // genera la vista previa
+          this.previewUrl && URL.revokeObjectURL(this.previewUrl); // liberar anterior
+          this.previewUrl = URL.createObjectURL(file);
         }
-    }
+      }
 
     private getCurrentPositionOnce(timeout = 10000): Promise<GeolocationPosition> {
         return new Promise((resolve, reject) => {
@@ -314,6 +321,7 @@ export class FormComplaintsComponent implements OnInit {
                 this.complaintForm.controls['contacted'].setValue(true);
                 this.submitted = false;
                 this.selectedPosition = null;
+                this.previewUrl = null;
             },
             error: (err) => {
                 // Si tu backend responde 401, muéstralo claro
@@ -324,5 +332,6 @@ export class FormComplaintsComponent implements OnInit {
             }
         });
     }
+
 
 }

--- a/src/app/pages/service/complaints.service.ts
+++ b/src/app/pages/service/complaints.service.ts
@@ -38,7 +38,7 @@ export class ComplaintsService {
         return this.http.get<FeedbackListResponse>(`${this.apiUrl}/private/feedback?page=1&limit=10`);
     }
 
-    createComplaint(payload: Omit<Feedback, '_id' | 'status' | 'dateRegister' | '__v'>) {
+    createComplaint(payload: FormData) {
         return this.http.post(`${this.apiUrl}/public/feedback`, payload);
     }
 


### PR DESCRIPTION
## Summary
- add file input to complaints form allowing images from camera or gallery
- include attachment control and send data as FormData
- update ComplaintsService to post multipart/form-data

## Testing
- `npm test` *(fails: No inputs were found in tsconfig.spec.json)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0e018073c832bb8f37eb422f623e4