### PR TITLE
feat: show complaint image or placeholder

### DIFF
--- a/src/app/pages/admin/complaints/complaints.html
+++ b/src/app/pages/admin/complaints/complaints.html
@@ -13,6 +13,7 @@
     </ng-template>
     <ng-template #header>
         <tr>
+            <th style="min-width: 10rem">Imagen</th>
             <th pSortableColumn="name" style="min-width: 16rem">Nombre</th>
             <th pSortableColumn="category" style="min-width: 10rem">Apellido</th>
             <th pSortableColumn="category" style="min-width: 10rem">Teléfono</th>
@@ -23,6 +24,14 @@
     </ng-template>
     <ng-template #body let-complaints>
         <tr>
+            <td>
+                <ng-container *ngIf="getAttachmentUrl(complaints) as imageUrl; else noImage">
+                    <img [src]="imageUrl" alt="Evidencia" class="w-16 h-16 object-cover rounded" />
+                </ng-container>
+                <ng-template #noImage>
+                    <span class="material-icons text-gray-400 text-4xl">image_not_supported</span>
+                </ng-template>
+            </td>
             <td style="min-width: 16rem">{{ complaints.firstName }}</td>
             <td>{{ complaints.lastName }}</td>
             <td>{{ complaints.phone }}</td>

--- a/src/app/pages/admin/complaints/complaints.ts
+++ b/src/app/pages/admin/complaints/complaints.ts
@@ -20,6 +20,7 @@ import { TextareaModule } from 'primeng/textarea';
 import { ToastModule } from 'primeng/toast';
 import { ToolbarModule } from 'primeng/toolbar';
 import { ComplaintsService, Feedback, FeedbackStatus } from '@/pages/service/complaints.service';
+import { environment } from 'src/environments/environment';
 
 interface Column {
     field: string;
@@ -104,6 +105,10 @@ export class Complaints implements OnInit {
 
     onGlobalFilter(table: Table, event: Event) {
         table.filterGlobal((event.target as HTMLInputElement).value, 'contains');
+    }
+
+    getAttachmentUrl(feedback: Feedback): string | null {
+        return feedback.attachment?.url ? `${environment.backendUrl}${feedback.attachment.url}` : null;
     }
 
     editComplaints(feedback: Feedback) {

--- a/src/app/pages/service/complaints.service.ts
+++ b/src/app/pages/service/complaints.service.ts
@@ -17,6 +17,12 @@ export interface Feedback {
     contacted: boolean;
     latitude: number;
     longitude: number;
+    attachment?: {
+        url?: string;
+        mimeType?: string;
+        size?: number;
+        originalName?: string;
+    };
     dateRegister: string; // ISO 8601 string
     __v: number;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://primefaces.org" />
     <link rel="icon" type="image/x-icon" href="https://primefaces.org/cdn/primeng/images/favicon.png" />
     <link href="https://fonts.cdnfonts.com/css/lato" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCYk6P2-xjdbZcUQI15gPCUsKUhnrkjXSs&libraries=places" async defer>
     </script>
 </head>


### PR DESCRIPTION
## Summary
- display complaint attachment image or Material icon placeholder
- add attachment info to Feedback interface
- expose helper to build full attachment URL

## Testing
- `npm test` *(fails: No inputs were found in config file 'tsconfig.spec.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c0f5ad238c832bb46123bd69cc3b67