### PR TITLE
feat: add image preview modal for complaints

### DIFF
--- a/src/app/pages/admin/complaints/complaints.html
+++ b/src/app/pages/admin/complaints/complaints.html
@@ -1,7 +1,18 @@
-<p-table #dt [value]="complaints()" [rows]="10" [columns]="cols" [paginator]="true" [globalFilterFields]="['status']"
-    [tableStyle]="{ 'min-width': '75rem' }" [(selection)]="selectedProducts" [rowHover]="true" dataKey="id"
-    currentPageReportTemplate="Showing {first} to {last} of {totalRecords} quejas" [showCurrentPageReport]="true"
-    [rowsPerPageOptions]="[10, 20, 30]">
+<p-table
+    #dt
+    [value]="complaints()"
+    [rows]="10"
+    [columns]="cols"
+    [paginator]="true"
+    [globalFilterFields]="['status']"
+    [tableStyle]="{ 'min-width': '75rem' }"
+    [(selection)]="selectedProducts"
+    [rowHover]="true"
+    dataKey="id"
+    currentPageReportTemplate="Showing {first} to {last} of {totalRecords} quejas"
+    [showCurrentPageReport]="true"
+    [rowsPerPageOptions]="[10, 20, 30]"
+>
     <ng-template #caption>
         <div class="flex items-center justify-between">
             <h5 class="m-0">Denuncias, Quejas o Sugerencias Ciudadanas</h5>
@@ -26,7 +37,7 @@
         <tr>
             <td>
                 <ng-container *ngIf="getAttachmentUrl(complaints) as imageUrl; else noImage">
-                    <img [src]="imageUrl" alt="Evidencia" class="w-16 h-16 object-cover rounded" />
+                    <img [src]="imageUrl" alt="Evidencia" class="w-16 h-16 object-cover rounded cursor-pointer" (click)="openImageDialog(complaints)" />
                 </ng-container>
                 <ng-template #noImage>
                     <span class="material-icons text-gray-400 text-4xl">image_not_supported</span>
@@ -40,10 +51,8 @@
                 <p-tag [value]="complaints.status" [severity]="getSeverity(complaints.status)" />
             </td>
             <td>
-                <p-button icon="pi pi-pencil" class="mr-2" [rounded]="true" [outlined]="true"
-                    (click)="editComplaints(complaints)" />
-                <p-button icon="pi pi-trash" severity="danger" [rounded]="true" [outlined]="true"
-                    (click)="cancelFeedback(complaints)" />
+                <p-button icon="pi pi-pencil" class="mr-2" [rounded]="true" [outlined]="true" (click)="editComplaints(complaints)" />
+                <p-button icon="pi pi-trash" severity="danger" [rounded]="true" [outlined]="true" (click)="cancelFeedback(complaints)" />
             </td>
         </tr>
     </ng-template>
@@ -58,17 +67,13 @@
             </div>
             <div>
                 <label for="description" class="block font-bold mb-3">Description</label>
-                <textarea id="description" pTextarea [(ngModel)]="feedback.description" required rows="3" cols="20"
-                    fluid></textarea>
+                <textarea id="description" pTextarea [(ngModel)]="feedback.description" required rows="3" cols="20" fluid></textarea>
             </div>
 
             <div>
                 <label for="status" class="block font-bold mb-3">Estado</label>
-                <p-select inputId="status" [(ngModel)]="feedback.status" [options]="statuses" optionLabel="label"
-                    optionValue="value" placeholder="Seleccione" class="w-full" />
+                <p-select inputId="status" [(ngModel)]="feedback.status" [options]="statuses" optionLabel="label" optionValue="value" placeholder="Seleccione" class="w-full" />
             </div>
-
-
         </div>
     </ng-template>
 

--- a/src/app/pages/admin/complaints/complaints.ts
+++ b/src/app/pages/admin/complaints/complaints.ts
@@ -21,6 +21,8 @@ import { ToastModule } from 'primeng/toast';
 import { ToolbarModule } from 'primeng/toolbar';
 import { ComplaintsService, Feedback, FeedbackStatus } from '@/pages/service/complaints.service';
 import { environment } from 'src/environments/environment';
+import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
+import { ImagePreviewDialogComponent } from '@/shared/components/image-preview-dialog/image-preview-dialog.component';
 
 interface Column {
     field: string;
@@ -54,11 +56,12 @@ interface ExportColumn {
         InputIconModule,
         IconFieldModule,
         ConfirmDialogModule,
-        Select
+        Select,
+        DynamicDialogModule
     ],
     templateUrl: './complaints.html',
     styleUrl: './complaints.scss',
-    providers: [MessageService, ProductService, ConfirmationService, ComplaintsService]
+    providers: [MessageService, ProductService, ConfirmationService, ComplaintsService, DialogService]
 })
 export class Complaints implements OnInit {
     complaintsDialog: boolean = false;
@@ -89,7 +92,8 @@ export class Complaints implements OnInit {
         private productService: ProductService,
         private messageService: MessageService,
         private confirmationService: ConfirmationService,
-        private complaintsService: ComplaintsService
+        private complaintsService: ComplaintsService,
+        private dialogService: DialogService
     ) {}
 
     ngOnInit() {
@@ -109,6 +113,23 @@ export class Complaints implements OnInit {
 
     getAttachmentUrl(feedback: Feedback): string | null {
         return feedback.attachment?.url ? `${environment.backendUrl}${feedback.attachment.url}` : null;
+    }
+
+    openImageDialog(feedback: Feedback) {
+        const imageUrl = this.getAttachmentUrl(feedback);
+        if (!imageUrl) {
+            return;
+        }
+        this.dialogService.open(ImagePreviewDialogComponent, {
+            data: {
+                imageUrl,
+                originalName: feedback.attachment?.originalName
+            },
+            header: feedback.attachment?.originalName,
+            width: '60vw',
+            modal: true,
+            dismissableMask: true
+        });
     }
 
     editComplaints(feedback: Feedback) {
@@ -156,16 +177,16 @@ export class Complaints implements OnInit {
 
     saveFeedback() {
         this.submitted = true;
-       // const updated = this.complaints().map((c) => (c._id === this.feedback._id ? { ...c, status: this.feedback.status } : c));
-       // this.complaints.set(updated);
-       this.complaintsService.updateFeedback(this.feedback).subscribe(() => {
+        // const updated = this.complaints().map((c) => (c._id === this.feedback._id ? { ...c, status: this.feedback.status } : c));
+        // this.complaints.set(updated);
+        this.complaintsService.updateFeedback(this.feedback).subscribe(() => {
             this.loadData();
             this.messageService.add({
                 severity: 'success',
                 summary: 'Successful',
                 detail: 'Queja actualizada',
                 life: 3000
-       })
+            });
         });
         this.submitted = false;
         this.feedback = {} as Feedback;

--- a/src/app/shared/components/image-preview-dialog/image-preview-dialog.component.ts
+++ b/src/app/shared/components/image-preview-dialog/image-preview-dialog.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+
+@Component({
+    selector: 'app-image-preview-dialog',
+    standalone: true,
+    imports: [CommonModule],
+    template: `
+        <div class="flex items-center justify-center p-4">
+            <img [src]="imageUrl" [alt]="originalName || 'Imagen'" class="max-w-full max-h-[80vh] object-contain" />
+        </div>
+    `
+})
+export class ImagePreviewDialogComponent {
+    imageUrl: string;
+    originalName?: string;
+
+    constructor(
+        public ref: DynamicDialogRef,
+        public config: DynamicDialogConfig
+    ) {
+        this.imageUrl = this.config.data?.imageUrl;
+        this.originalName = this.config.data?.originalName;
+    }
+}


### PR DESCRIPTION
## Summary
- allow viewing complaint images in a modal dialog
- create reusable `ImagePreviewDialogComponent` for large image preview

## Testing
- `npm run format`
- `npm test` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f8a3a2b4832b9dda4b60fb071082