### PR TITLE
Implement companies administration table

### DIFF
--- a/src/app/pages/admin/companies/companies.html
+++ b/src/app/pages/admin/companies/companies.html
@@ -1,1 +1,104 @@
-<p>companies works!</p>
+<p-toast />
+
+<p-table
+    #dt
+    [value]="companies()"
+    [paginator]="true"
+    [rows]="10"
+    [totalRecords]="totalRecords"
+    [lazy]="true"
+    (onLazyLoad)="loadCompaniesLazy($event)"
+    dataKey="_id"
+    currentPageReportTemplate="Del {first} al {last} de {totalRecords} empresas"
+    [showCurrentPageReport]="true"
+    [rowsPerPageOptions]="[10, 20, 30]"
+    [loading]="loading"
+>
+    <ng-template #caption>
+        <div class="flex items-center justify-between">
+            <h5 class="m-0">Empresas registradas</h5>
+            <p-iconfield>
+                <p-inputicon styleClass="pi pi-search" />
+                <input pInputText type="text" (input)="onGlobalFilter(dt, $event)" placeholder="Buscar..." />
+            </p-iconfield>
+        </div>
+    </ng-template>
+    <ng-template #header>
+        <tr>
+            <th pSortableColumn="name" style="min-width: 12rem">Nombre</th>
+            <th pSortableColumn="description" style="min-width: 16rem">Descripción</th>
+            <th pSortableColumn="status" style="min-width: 10rem">Estado</th>
+            <th style="min-width: 10rem">Contactos</th>
+            <th style="width: 8rem"></th>
+        </tr>
+    </ng-template>
+    <ng-template #body let-company>
+        <tr>
+            <td>{{ company.name }}</td>
+            <td>{{ company.description }}</td>
+            <td>
+                <p-tag [value]="getStatusLabel(company.status)" [severity]="getStatusSeverity(company.status)" />
+            </td>
+            <td>{{ company.contacts?.length || 0 }}</td>
+            <td class="flex gap-2">
+                <p-button icon="pi pi-pencil" [rounded]="true" [outlined]="true" (click)="editCompany(company)" />
+                <p-button icon="pi pi-trash" severity="danger" [rounded]="true" [outlined]="true" (click)="confirmDeleteCompany(company)" />
+            </td>
+        </tr>
+    </ng-template>
+</p-table>
+
+<p-dialog [(visible)]="companyDialog" [style]="{ width: '450px' }" header="Editar empresa" [modal]="true">
+    <ng-template #content>
+        <ng-container *ngIf="selectedCompany as company">
+            <div class="flex flex-col gap-6">
+                <div>
+                    <label for="name" class="block font-bold mb-3">Nombre</label>
+                    <input
+                        type="text"
+                        pInputText
+                        id="name"
+                        [(ngModel)]="company.name"
+                        required
+                        autofocus
+                        fluid
+                    />
+                    <small class="p-error" *ngIf="submitted && !company.name">El nombre es obligatorio</small>
+                </div>
+                <div>
+                    <label for="description" class="block font-bold mb-3">Descripción</label>
+                    <textarea
+                        id="description"
+                        pTextarea
+                        [(ngModel)]="company.description"
+                        required
+                        rows="3"
+                        cols="20"
+                        fluid
+                    ></textarea>
+                    <small class="p-error" *ngIf="submitted && !company.description">La descripción es obligatoria</small>
+                </div>
+                <div>
+                    <label for="status" class="block font-bold mb-3">Estado</label>
+                    <p-select
+                        inputId="status"
+                        [(ngModel)]="company.status"
+                        [options]="statuses"
+                        optionLabel="label"
+                        optionValue="value"
+                        placeholder="Seleccione"
+                        class="w-full"
+                    />
+                    <small class="p-error" *ngIf="submitted && !company.status">El estado es obligatorio</small>
+                </div>
+            </div>
+        </ng-container>
+    </ng-template>
+
+    <ng-template #footer>
+        <p-button label="Cancelar" icon="pi pi-times" text (click)="hideDialog()" />
+        <p-button label="Guardar" icon="pi pi-check" (click)="saveCompany()" />
+    </ng-template>
+</p-dialog>
+
+<p-confirmdialog [style]="{ width: '450px' }" />

--- a/src/app/pages/admin/companies/companies.ts
+++ b/src/app/pages/admin/companies/companies.ts
@@ -1,11 +1,213 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TableModule, Table, TableLazyLoadEvent } from 'primeng/table';
+import { ButtonModule } from 'primeng/button';
+import { TagModule } from 'primeng/tag';
+import { InputTextModule } from 'primeng/inputtext';
+import { IconFieldModule } from 'primeng/iconfield';
+import { InputIconModule } from 'primeng/inputicon';
+import { DialogModule } from 'primeng/dialog';
+import { TextareaModule } from 'primeng/textarea';
+import { ToastModule } from 'primeng/toast';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { Select } from 'primeng/select';
+import { RippleModule } from 'primeng/ripple';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { CompaniesService, Company, CompanyStatus } from '@/pages/service/companies.service';
+
+interface CompanyStatusOption {
+    label: string;
+    value: CompanyStatus;
+}
 
 @Component({
-  selector: 'app-companies',
-  imports: [],
-  templateUrl: './companies.html',
-  styleUrl: './companies.scss'
+    selector: 'app-companies',
+    standalone: true,
+    templateUrl: './companies.html',
+    styleUrl: './companies.scss',
+    imports: [
+        CommonModule,
+        TableModule,
+        FormsModule,
+        ButtonModule,
+        TagModule,
+        InputTextModule,
+        IconFieldModule,
+        InputIconModule,
+        DialogModule,
+        TextareaModule,
+        ToastModule,
+        ConfirmDialogModule,
+        Select,
+        RippleModule
+    ],
+    providers: [MessageService, ConfirmationService, CompaniesService]
 })
-export class Companies {
+export class Companies implements OnInit {
+    companies = signal<Company[]>([]);
+    totalRecords = 0;
+    loading = false;
 
+    companyDialog = false;
+    selectedCompany: Company | null = null;
+    submitted = false;
+
+    statuses: CompanyStatusOption[] = [
+        { label: 'Activa', value: 'ACT' },
+        { label: 'Inactiva', value: 'INA' }
+    ];
+
+    private lastLazyEvent: TableLazyLoadEvent | null = null;
+
+    constructor(
+        private companiesService: CompaniesService,
+        private messageService: MessageService,
+        private confirmationService: ConfirmationService
+    ) {}
+
+    ngOnInit() {
+        const initialEvent: TableLazyLoadEvent = { first: 0, rows: 10 };
+        this.loadCompaniesLazy(initialEvent);
+    }
+
+    loadCompaniesLazy(event: TableLazyLoadEvent) {
+        this.lastLazyEvent = { ...event };
+        const first = event.first ?? 0;
+        const rows = event.rows && event.rows > 0 ? event.rows : 10;
+        const page = Math.floor(first / rows) + 1;
+        const limit = rows;
+
+        this.loading = true;
+
+        this.companiesService.getCompanies(page, limit).subscribe({
+            next: (response) => {
+                this.companies.set(response.data);
+                this.totalRecords = response.total;
+                this.loading = false;
+            },
+            error: () => {
+                this.loading = false;
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'No se pudieron cargar las empresas',
+                    life: 3000
+                });
+            }
+        });
+    }
+
+    onGlobalFilter(table: Table, event: Event) {
+        table.filterGlobal((event.target as HTMLInputElement).value, 'contains');
+    }
+
+    getStatusSeverity(status: CompanyStatus) {
+        switch (status) {
+            case 'ACT':
+                return 'success';
+            case 'INA':
+                return 'danger';
+            default:
+                return 'info';
+        }
+    }
+
+    getStatusLabel(status: CompanyStatus) {
+        switch (status) {
+            case 'ACT':
+                return 'Activa';
+            case 'INA':
+                return 'Inactiva';
+            default:
+                return status;
+        }
+    }
+
+    editCompany(company: Company) {
+        this.selectedCompany = {
+            ...company,
+            contacts: company.contacts ? [...company.contacts] : []
+        };
+        this.companyDialog = true;
+    }
+
+    hideDialog() {
+        this.companyDialog = false;
+        this.submitted = false;
+        this.selectedCompany = null;
+    }
+
+    saveCompany() {
+        this.submitted = true;
+
+        if (!this.selectedCompany) {
+            return;
+        }
+
+        const name = this.selectedCompany.name?.trim();
+        const description = this.selectedCompany.description?.trim();
+        const status = this.selectedCompany.status;
+
+        if (!name || !description || !status) {
+            return;
+        }
+
+        this.companiesService.updateCompany(this.selectedCompany._id, { name, description, status }).subscribe({
+            next: () => {
+                this.messageService.add({
+                    severity: 'success',
+                    summary: 'Éxito',
+                    detail: 'Empresa actualizada correctamente',
+                    life: 3000
+                });
+                this.hideDialog();
+                this.reloadCurrentPage();
+            },
+            error: () => {
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'No se pudo actualizar la empresa',
+                    life: 3000
+                });
+            }
+        });
+    }
+
+    confirmDeleteCompany(company: Company) {
+        this.confirmationService.confirm({
+            message: `¿Está seguro de eliminar la empresa ${company.name}?`,
+            header: 'Confirmar',
+            icon: 'pi pi-exclamation-triangle',
+            acceptButtonProps: { label: 'Sí', icon: 'pi pi-check' },
+            rejectButtonProps: { label: 'No', icon: 'pi pi-times', class: 'p-button-text' },
+            accept: () => {
+                this.companiesService.deleteCompany(company._id).subscribe({
+                    next: () => {
+                        this.messageService.add({
+                            severity: 'success',
+                            summary: 'Éxito',
+                            detail: 'Empresa eliminada correctamente',
+                            life: 3000
+                        });
+                        this.reloadCurrentPage();
+                    },
+                    error: () => {
+                        this.messageService.add({
+                            severity: 'error',
+                            summary: 'Error',
+                            detail: 'No se pudo eliminar la empresa',
+                            life: 3000
+                        });
+                    }
+                });
+            }
+        });
+    }
+
+    private reloadCurrentPage() {
+        const fallbackEvent: TableLazyLoadEvent = { first: 0, rows: 10 };
+        this.loadCompaniesLazy(this.lastLazyEvent ?? fallbackEvent);
+    }
 }

--- a/src/app/pages/service/companies.service.ts
+++ b/src/app/pages/service/companies.service.ts
@@ -1,0 +1,71 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment';
+
+export type CompanyStatus = 'ACT' | 'INA' | string;
+
+export interface CompanyContactUser {
+    _id: string;
+    username: string;
+    email: string;
+    password: string;
+    role: string;
+    isFirstLogin: boolean;
+    __v: number;
+    personalData: string;
+}
+
+export interface CompanyContact {
+    _id: string;
+    name: string;
+    lastname: string;
+    dni: string;
+    user: CompanyContactUser;
+    __v: number;
+}
+
+export interface Company {
+    _id: string;
+    name: string;
+    description: string;
+    status: CompanyStatus;
+    __v: number;
+    contacts: CompanyContact[];
+}
+
+export interface CompanyListResponse {
+    data: Company[];
+    total: number;
+    page: number;
+    limit: number;
+}
+
+export interface UpdateCompanyPayload {
+    name: string;
+    description: string;
+    status: CompanyStatus;
+}
+
+@Injectable()
+export class CompaniesService {
+    private readonly apiUrl = environment.backendUrl;
+    private readonly companiesEndpoint = `${this.apiUrl}/private/company`;
+
+    constructor(private http: HttpClient) {}
+
+    getCompanies(page: number = 1, limit: number = 10, search?: string) {
+        let params = new HttpParams().set('page', page).set('limit', limit);
+        if (search && search.trim().length > 0) {
+            params = params.set('search', search.trim());
+        }
+        return this.http.get<CompanyListResponse>(this.companiesEndpoint, { params });
+    }
+
+    updateCompany(companyId: string, payload: UpdateCompanyPayload) {
+        return this.http.patch(`${this.companiesEndpoint}/${companyId}`, payload);
+    }
+
+    deleteCompany(companyId: string) {
+        return this.http.delete(`${this.companiesEndpoint}/${companyId}`);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated companies service for retrieving, updating and deleting company data
- build a PrimeNG table in the companies page with lazy pagination, search, status tags and action buttons
- add an edit dialog with validation plus confirmation and toast notifications for destructive actions

## Testing
- npm run build *(fails: npm command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca11557e28832b9d137d147a9af468