### PR TITLE
feat: allow assigning contacts to companies

### DIFF
--- a/src/app/pages/admin/companies/companies.html
+++ b/src/app/pages/admin/companies/companies.html
@@ -19,7 +19,7 @@
             <th pSortableColumn="description" style="min-width: 16rem">Descripción</th>
             <th pSortableColumn="status" style="min-width: 10rem">Estado</th>
             <th style="min-width: 10rem">Contactos</th>
-            <th style="width: 8rem"></th>
+            <th style="width: 12rem"></th>
         </tr>
     </ng-template>
     <ng-template #body let-company>
@@ -31,6 +31,8 @@
             </td>
             <td>{{ company.contacts?.length || 0 }}</td>
             <td class="flex gap-2">
+                <p-button icon="pi pi-user-plus" severity="success" [rounded]="true" [outlined]="true"
+                    (click)="openAssignContactDialog(company)" ariaLabel="Agregar contacto" />
                 <p-button icon="pi pi-pencil" [rounded]="true" [outlined]="true" (click)="editCompany(company)" />
                 <p-button icon="pi pi-trash" severity="danger" [rounded]="true" [outlined]="true"
                     (click)="confirmDeleteCompany(company)" />
@@ -99,6 +101,65 @@
     <ng-template #footer>
         <p-button label="Cancelar" icon="pi pi-times" text (click)="hideDialog()" />
         <p-button label="Guardar" icon="pi pi-check" (click)="saveCompany()" />
+    </ng-template>
+</p-dialog>
+
+<p-dialog [(visible)]="assignContactDialog" [style]="{ width: '720px' }" header="Agregar contacto" [modal]="true"
+    (onHide)="onAssignContactDialogHide()">
+    <ng-template #content>
+        <ng-container *ngIf="selectedCompanyForContact as company">
+            <p class="mb-4 text-sm text-gray-600">
+                Selecciona un contacto para asignar a <strong>{{ company.name }}</strong>.
+            </p>
+
+            <p-table [value]="availableContacts()" [paginator]="true" [rows]="availableContactsRows"
+                [totalRecords]="availableContactsTotal" [lazy]="true" (onLazyLoad)="loadAvailableContacts($event)"
+                [rowsPerPageOptions]="[10, 20, 30]" [loading]="availableContactsLoading" dataKey="_id"
+                currentPageReportTemplate="Del {first} al {last} de {totalRecords} empleados" [showCurrentPageReport]="true">
+                <ng-template #header>
+                    <tr>
+                        <th>Nombre completo</th>
+                        <th>DNI</th>
+                        <th>Email</th>
+                        <th>Teléfono</th>
+                        <th style="width: 8rem"></th>
+                    </tr>
+                </ng-template>
+                <ng-template #body let-user>
+                    <tr>
+                        <td>{{ user.personalData?.name || 'Sin nombre' }} {{ user.personalData?.lastname || '' }}</td>
+                        <td>{{ user.personalData?.dni || 'Sin DNI' }}</td>
+                        <td>{{ user.email }}</td>
+                        <td>{{ user.personalData?.phone || 'Sin teléfono' }}</td>
+                        <td class="text-right">
+                            <p-button label="Seleccionar" icon="pi pi-user-plus" size="small"
+                                (click)="assignContact(user)" [loading]="assigningContactId === user._id"
+                                [disabled]="assigningContactId !== null && assigningContactId !== user._id" />
+                        </td>
+                    </tr>
+                </ng-template>
+                <ng-template #emptymessage>
+                    <tr>
+                        <td colspan="5" class="py-4 text-center text-gray-500">
+                            No hay usuarios disponibles para asignar.
+                        </td>
+                    </tr>
+                </ng-template>
+                <ng-template #loading>
+                    <tr>
+                        <td colspan="5">
+                            <div class="flex items-center justify-center py-6">
+                                <p-progressSpinner styleClass="w-8 h-8" strokeWidth="4" />
+                            </div>
+                        </td>
+                    </tr>
+                </ng-template>
+            </p-table>
+        </ng-container>
+    </ng-template>
+
+    <ng-template #footer>
+        <p-button label="Cerrar" icon="pi pi-times" text (click)="closeAssignContactDialog()" />
     </ng-template>
 </p-dialog>
 

--- a/src/app/pages/admin/companies/companies.html
+++ b/src/app/pages/admin/companies/companies.html
@@ -74,17 +74,24 @@
                                 </ng-template>
 
                                 <ng-template pTemplate="subtitle">
-                                    <p-tag value="{{ getRoleLabel(contact.user.role)  || 'Empleado' }}" severity="info"></p-tag>
+                                    <p-tag value="{{ getRoleLabel(contact.user.role)  || 'Empleado' }}"
+                                        severity="info"></p-tag>
                                 </ng-template>
 
                                 <ng-template pTemplate="content">
-                                    <div class="text-sm text-gray-700">
-                                        <p><i class="pi pi-envelope mr-2 text-blue-500"></i>{{ contact.user.email }}
-                                        </p>
-                                        <p><i class="pi pi-phone mr-2 text-green-500"></i>{{ contact.phone || 'No registrado' }}</p>
+                                    <div class="text-sm text-gray-700 space-y-2">
+                                        <p><i class="pi pi-envelope mr-2 text-blue-500"></i>{{ contact.user.email }}</p>
+                                        <p><i class="pi pi-phone mr-2 text-green-500"></i>{{ contact.phone || 'No
+                                            registrado' }}</p>
                                         <p><i class="pi pi-id-card mr-2 text-purple-500"></i>{{ contact.dni }}</p>
+
+                                        <div class="flex justify-end">
+                                            <p-button label="Eliminar" icon="pi pi-trash" severity="danger" outlined
+                                                size="small" (click)="removeContact(contact._id)" />
+                                        </div>
                                     </div>
                                 </ng-template>
+
                             </p-card>
                         </ng-container>
 
@@ -115,7 +122,8 @@
             <p-table [value]="availableContacts()" [paginator]="true" [rows]="availableContactsRows"
                 [totalRecords]="availableContactsTotal" [lazy]="true" (onLazyLoad)="loadAvailableContacts($event)"
                 [rowsPerPageOptions]="[10, 20, 30]" [loading]="availableContactsLoading" dataKey="_id"
-                currentPageReportTemplate="Del {first} al {last} de {totalRecords} empleados" [showCurrentPageReport]="true">
+                currentPageReportTemplate="Del {first} al {last} de {totalRecords} empleados"
+                [showCurrentPageReport]="true">
                 <ng-template #header>
                     <tr>
                         <th>Nombre completo</th>

--- a/src/app/pages/admin/companies/companies.ts
+++ b/src/app/pages/admin/companies/companies.ts
@@ -339,4 +339,41 @@ export class Companies implements OnInit {
         this.availableContactsRows = 10;
         this.assigningContactId = null;
     }
+
+    removeContact(idContact: string) {
+        if (!this.selectedCompany) {
+            return;
+        }
+
+        if (!idContact) {
+            this.messageService.add({
+                severity: 'error',
+                summary: 'Error',
+                detail: 'El contacto seleccionado no tiene información personal válida',
+                life: 3000
+            });
+            return;
+        }
+
+        this.companiesService.removeUserFromCompany(this.selectedCompany._id, idContact).subscribe({
+            next: () => {
+                this.messageService.add({
+                    severity: 'success',
+                    summary: 'Éxito',
+                    detail: 'Contacto removido correctamente',
+                    life: 3000
+                });
+                this.reloadCurrentPage();
+                this.hideDialog();
+            },
+            error: () => {
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'No se pudo remover el contacto',
+                    life: 3000
+                });
+            }
+        });
+    }
 }

--- a/src/app/pages/service/companies.service.ts
+++ b/src/app/pages/service/companies.service.ts
@@ -41,6 +41,28 @@ export interface CompanyListResponse {
     limit: number;
 }
 
+export interface NotAssignedUserPersonalData {
+    _id: string;
+    name: string;
+    lastname: string;
+    dni: string;
+    phone: string;
+}
+
+export interface NotAssignedUser {
+    _id: string;
+    username: string;
+    email: string;
+    personalData?: NotAssignedUserPersonalData | null;
+}
+
+export interface NotAssignedUsersResponse {
+    data: NotAssignedUser[];
+    total: number;
+    page: number;
+    limit: number;
+}
+
 export interface UpdateCompanyPayload {
     name: string;
     description: string;
@@ -51,6 +73,7 @@ export interface UpdateCompanyPayload {
 export class CompaniesService {
     private readonly apiUrl = environment.backendUrl;
     private readonly companiesEndpoint = `${this.apiUrl}/private/companies`;
+    private readonly notAssignedUsersEndpoint = `${this.apiUrl}/auth/users/not-assigned`;
 
     constructor(private http: HttpClient) { }
 
@@ -76,5 +99,10 @@ export class CompaniesService {
 
     removeUserFromCompany(companyId: string, userId: string) {
         return this.http.delete(`${this.companiesEndpoint}/${companyId}/contacts/${userId}`);
+    }
+
+    getNotAssignedUsers(page: number = 1, limit: number = 10) {
+        const params = new HttpParams().set('page', page).set('limit', limit);
+        return this.http.get<NotAssignedUsersResponse>(this.notAssignedUsersEndpoint, { params });
     }
 }

--- a/src/app/pages/service/companies.service.ts
+++ b/src/app/pages/service/companies.service.ts
@@ -97,8 +97,8 @@ export class CompaniesService {
         return this.http.post(`${this.companiesEndpoint}/${companyId}/contacts`, { personId });
     }
 
-    removeUserFromCompany(companyId: string, userId: string) {
-        return this.http.delete(`${this.companiesEndpoint}/${companyId}/contacts/${userId}`);
+    removeUserFromCompany(companyId: string, personId: string) {
+        return this.http.patch(`${this.companiesEndpoint}/${companyId}/contacts`, { personId });
     }
 
     getNotAssignedUsers(page: number = 1, limit: number = 10) {


### PR DESCRIPTION
## Summary
- add data models and service call to retrieve unassigned users for contact assignment
- extend the companies component with an "Agregar contacto" action, dialog and paginated table
- handle contact assignment workflow with loading states, toast messages and page refreshes

## Testing
- npm run build *(fails: font inlining request to https://fonts.googleapis.com/icon?family=Material+Icons returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ca25b2aef0832b9d96d4b1b043aa0b