### PR TITLE
feat: add users management table

### DIFF
--- a/src/app/pages/admin/users/users.html
+++ b/src/app/pages/admin/users/users.html
@@ -1,1 +1,189 @@
-<p>users works!</p>
+<p-toast />
+<p-confirmDialog />
+
+<p-table
+    #dt
+    [value]="users()"
+    [lazy]="true"
+    [paginator]="true"
+    [rows]="rows"
+    [totalRecords]="totalRecords"
+    (onLazyLoad)="loadUsers($event)"
+    [loading]="loading"
+    dataKey="_id"
+    currentPageReportTemplate="Del {first} al {last} de {totalRecords} usuarios"
+    [showCurrentPageReport]="true"
+    [rowsPerPageOptions]="[5, 10, 20, 50]"
+    class="shadow-sm"
+>
+    <ng-template #caption>
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div class="flex flex-col gap-1">
+                <h2 class="text-lg font-semibold text-surface-900 dark:text-surface-0 m-0">
+                    Usuarios registrados
+                </h2>
+                <p class="text-sm text-surface-500 dark:text-surface-400 m-0">
+                    Administra los usuarios del sistema.
+                </p>
+            </div>
+            <div class="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+                <p-iconfield class="w-full md:w-72">
+                    <p-inputicon styleClass="pi pi-search" />
+                    <input
+                        pInputText
+                        type="text"
+                        class="w-full"
+                        placeholder="Buscar usuarios"
+                        [value]="searchValue"
+                        (input)="onSearch($event)"
+                    />
+                </p-iconfield>
+                <p-button
+                    *ngIf="searchTerm()"
+                    label="Limpiar"
+                    icon="pi pi-times"
+                    severity="secondary"
+                    text
+                    (click)="clearSearch()"
+                    class="md:w-auto"
+                />
+                <p-button label="Agregar" icon="pi pi-plus" (click)="addUser()" class="md:w-auto" />
+            </div>
+        </div>
+    </ng-template>
+
+    <ng-template #header>
+        <tr>
+            <th style="min-width: 10rem">Nombre</th>
+            <th style="min-width: 10rem">Apellido</th>
+            <th style="min-width: 10rem">Usuario</th>
+            <th style="min-width: 14rem">Email</th>
+            <th style="width: 12rem">Acciones</th>
+        </tr>
+    </ng-template>
+
+    <ng-template #body let-user>
+        <tr>
+            <td>{{ user.personalData?.name || '' }}</td>
+            <td>{{ user.personalData?.lastname || '' }}</td>
+            <td>{{ user.username }}</td>
+            <td>{{ user.email }}</td>
+            <td>
+                <div class="flex flex-wrap gap-2">
+                    <p-button
+                        label="Editar"
+                        icon="pi pi-pencil"
+                        outlined
+                        size="small"
+                        (click)="editUser(user)"
+                    />
+                    <p-button
+                        label="Eliminar"
+                        icon="pi pi-trash"
+                        severity="danger"
+                        outlined
+                        size="small"
+                        (click)="deleteUser(user)"
+                    />
+                </div>
+            </td>
+        </tr>
+    </ng-template>
+
+    <ng-template #emptymessage>
+        <tr>
+            <td colspan="5" class="py-6 text-center text-surface-500 dark:text-surface-400">
+                No se encontraron usuarios.
+            </td>
+        </tr>
+    </ng-template>
+</p-table>
+
+<p-dialog
+    [(visible)]="userDialog"
+    [modal]="true"
+    [style]="{ width: '40rem' }"
+    [breakpoints]="{ '960px': '90vw', '640px': '95vw' }"
+    [dismissableMask]="true"
+    (onHide)="hideDialog()"
+    [header]="isEditMode ? 'Editar usuario' : 'Agregar usuario'"
+>
+    <ng-template #content>
+        <form [formGroup]="userForm" (ngSubmit)="saveUser()" class="flex flex-col gap-4">
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                    <label for="username" class="block font-semibold mb-2">Usuario</label>
+                    <input id="username" type="text" pInputText formControlName="username" fluid />
+                    <small class="text-red-500" *ngIf="isInvalid('username')">
+                        El usuario es obligatorio.
+                    </small>
+                </div>
+                <div>
+                    <label for="email" class="block font-semibold mb-2">Email</label>
+                    <input id="email" type="email" pInputText formControlName="email" fluid />
+                    <small class="text-red-500" *ngIf="isInvalid('email')">
+                        Ingrese un email válido.
+                    </small>
+                </div>
+                <div>
+                    <label for="role" class="block font-semibold mb-2">Rol</label>
+                    <p-select
+                        inputId="role"
+                        formControlName="role"
+                        [options]="roleOptions"
+                        optionLabel="label"
+                        optionValue="value"
+                        placeholder="Seleccione un rol"
+                        class="w-full"
+                    />
+                    <small class="text-red-500" *ngIf="isInvalid('role')">
+                        Seleccione un rol.
+                    </small>
+                </div>
+                <div class="flex items-center gap-2 pt-6">
+                    <p-checkbox
+                        inputId="isFirstLogin"
+                        formControlName="isFirstLogin"
+                        [binary]="true"
+                        label="Primer inicio de sesión"
+                    />
+                </div>
+                <div *ngIf="!isEditMode" class="md:col-span-2">
+                    <label for="password" class="block font-semibold mb-2">Contraseña</label>
+                    <input id="password" type="password" pInputText formControlName="password" fluid />
+                    <small class="text-red-500" *ngIf="isInvalid('password')">
+                        La contraseña es obligatoria y debe tener al menos 8 caracteres.
+                    </small>
+                </div>
+            </div>
+
+            <div formGroupName="personalData" class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                    <label for="name" class="block font-semibold mb-2">Nombre</label>
+                    <input id="name" type="text" pInputText formControlName="name" fluid />
+                </div>
+                <div>
+                    <label for="lastname" class="block font-semibold mb-2">Apellido</label>
+                    <input id="lastname" type="text" pInputText formControlName="lastname" fluid />
+                </div>
+                <div>
+                    <label for="dni" class="block font-semibold mb-2">DNI</label>
+                    <input id="dni" type="text" pInputText formControlName="dni" fluid />
+                </div>
+                <div>
+                    <label for="phone" class="block font-semibold mb-2">Teléfono</label>
+                    <input id="phone" type="text" pInputText formControlName="phone" fluid />
+                </div>
+            </div>
+
+            <div class="flex justify-end gap-3 pt-2">
+                <p-button type="button" label="Cancelar" icon="pi pi-times" text (click)="hideDialog()" />
+                <p-button
+                    type="submit"
+                    [label]="isEditMode ? 'Guardar cambios' : 'Crear usuario'"
+                    icon="pi pi-check"
+                />
+            </div>
+        </form>
+    </ng-template>
+</p-dialog>

--- a/src/app/pages/admin/users/users.ts
+++ b/src/app/pages/admin/users/users.ts
@@ -1,11 +1,367 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, signal } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { TableModule, TableLazyLoadEvent } from 'primeng/table';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { DialogModule } from 'primeng/dialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { IconFieldModule } from 'primeng/iconfield';
+import { InputIconModule } from 'primeng/inputicon';
+import { CheckboxModule } from 'primeng/checkbox';
+import { RippleModule } from 'primeng/ripple';
+import { Select } from 'primeng/select';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { Subject, debounceTime, distinctUntilChanged } from 'rxjs';
+import {
+    UsersService,
+    User,
+    CreateUserPayload,
+    UpdateUserPayload,
+    PersonalData
+} from '@/pages/service/users.service';
+
+interface RoleOption {
+    label: string;
+    value: string;
+}
 
 @Component({
-  selector: 'app-users',
-  imports: [],
-  templateUrl: './users.html',
-  styleUrl: './users.scss'
+    selector: 'app-users',
+    standalone: true,
+    templateUrl: './users.html',
+    styleUrl: './users.scss',
+    imports: [
+        CommonModule,
+        FormsModule,
+        ReactiveFormsModule,
+        TableModule,
+        ButtonModule,
+        ToastModule,
+        ConfirmDialogModule,
+        DialogModule,
+        InputTextModule,
+        IconFieldModule,
+        InputIconModule,
+        CheckboxModule,
+        RippleModule,
+        Select
+    ],
+    providers: [MessageService, ConfirmationService, UsersService]
 })
-export class Users {
+export class Users implements OnInit {
+    readonly users = signal<User[]>([]);
+    readonly searchTerm = signal('');
 
+    totalRecords = 0;
+    rows = 10;
+    loading = false;
+
+    userDialog = false;
+    submitted = false;
+    isEditMode = false;
+
+    searchValue = '';
+
+    readonly roleOptions: RoleOption[] = [
+        { label: 'Administrador', value: 'ADMIN' },
+        { label: 'Empleado', value: 'EMPLOYEE' }
+    ];
+
+    readonly userForm: FormGroup;
+
+    private readonly search$ = new Subject<string>();
+    private lastLazyEvent: TableLazyLoadEvent | null = null;
+    private selectedUser: User | null = null;
+
+    constructor(
+        private readonly fb: FormBuilder,
+        private readonly usersService: UsersService,
+        private readonly messageService: MessageService,
+        private readonly confirmationService: ConfirmationService
+    ) {
+        this.userForm = this.fb.group({
+            username: ['', Validators.required],
+            email: ['', [Validators.required, Validators.email]],
+            role: ['EMPLOYEE', Validators.required],
+            isFirstLogin: [false],
+            password: [''],
+            personalData: this.fb.group({
+                name: [''],
+                lastname: [''],
+                dni: [''],
+                phone: ['']
+            })
+        });
+
+        this.search$
+            .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed())
+            .subscribe((term) => {
+                this.searchTerm.set(term.trim());
+                this.reloadUsers(true);
+            });
+    }
+
+    ngOnInit(): void {
+        const initialEvent: TableLazyLoadEvent = { first: 0, rows: this.rows };
+        this.loadUsers(initialEvent);
+    }
+
+    loadUsers(event: TableLazyLoadEvent): void {
+        this.lastLazyEvent = { ...event };
+        const first = event.first ?? 0;
+        const rows = event.rows && event.rows > 0 ? event.rows : this.rows;
+        this.rows = rows;
+
+        const page = Math.floor(first / rows) + 1;
+        const limit = rows;
+        const search = this.searchTerm();
+
+        this.loading = true;
+
+        this.usersService.getUsers(page, limit, search).subscribe({
+            next: (response) => {
+                this.users.set(response.data);
+                this.totalRecords = response.total;
+                this.loading = false;
+            },
+            error: () => {
+                this.loading = false;
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'No se pudieron cargar los usuarios',
+                    life: 3000
+                });
+            }
+        });
+    }
+
+    addUser(): void {
+        this.isEditMode = false;
+        this.submitted = false;
+        this.selectedUser = null;
+        this.resetForm();
+        this.setPasswordValidators(true);
+        this.userDialog = true;
+    }
+
+    editUser(user: User): void {
+        this.isEditMode = true;
+        this.submitted = false;
+        this.selectedUser = user;
+        this.resetForm();
+        this.setPasswordValidators(false);
+
+        this.userForm.patchValue({
+            username: user.username,
+            email: user.email,
+            role: user.role || 'EMPLOYEE',
+            isFirstLogin: user.isFirstLogin ?? false,
+            password: ''
+        });
+
+        const personalDataGroup = this.userForm.get('personalData') as FormGroup;
+        personalDataGroup.patchValue({
+            name: user.personalData?.name ?? '',
+            lastname: user.personalData?.lastname ?? '',
+            dni: user.personalData?.dni ?? '',
+            phone: user.personalData?.phone ?? ''
+        });
+
+        this.userDialog = true;
+    }
+
+    deleteUser(user: User): void {
+        this.confirmationService.confirm({
+            message: `¿Está seguro de eliminar al usuario ${user.username}?`,
+            header: 'Confirmar',
+            icon: 'pi pi-exclamation-triangle',
+            acceptButtonProps: { label: 'Sí', icon: 'pi pi-check' },
+            rejectButtonProps: { label: 'No', icon: 'pi pi-times', class: 'p-button-text' },
+            accept: () => {
+                this.usersService.deleteUser(user._id).subscribe({
+                    next: () => {
+                        this.messageService.add({
+                            severity: 'success',
+                            summary: 'Éxito',
+                            detail: 'Usuario eliminado correctamente',
+                            life: 3000
+                        });
+                        this.reloadUsers();
+                    },
+                    error: () => {
+                        this.messageService.add({
+                            severity: 'error',
+                            summary: 'Error',
+                            detail: 'No se pudo eliminar el usuario',
+                            life: 3000
+                        });
+                    }
+                });
+            }
+        });
+    }
+
+    saveUser(): void {
+        this.submitted = true;
+
+        if (this.userForm.invalid) {
+            this.userForm.markAllAsTouched();
+            return;
+        }
+
+        const formValue = this.userForm.getRawValue();
+
+        if (this.isEditMode && this.selectedUser) {
+            const payload: UpdateUserPayload = {
+                username: formValue.username?.trim(),
+                email: formValue.email?.trim(),
+                role: formValue.role,
+                isFirstLogin: formValue.isFirstLogin ?? false,
+                personalData: this.buildPersonalData(formValue.personalData)
+            };
+
+            this.usersService.updateUser(this.selectedUser._id, payload).subscribe({
+                next: () => {
+                    this.messageService.add({
+                        severity: 'success',
+                        summary: 'Éxito',
+                        detail: 'Usuario actualizado correctamente',
+                        life: 3000
+                    });
+                    this.hideDialog();
+                    this.reloadUsers();
+                },
+                error: () => {
+                    this.messageService.add({
+                        severity: 'error',
+                        summary: 'Error',
+                        detail: 'No se pudo actualizar el usuario',
+                        life: 3000
+                    });
+                }
+            });
+            return;
+        }
+
+        const payload: CreateUserPayload = {
+            username: formValue.username?.trim(),
+            email: formValue.email?.trim(),
+            password: formValue.password?.trim() || '',
+            name: formValue.personalData?.name?.trim() ?? '',
+            lastname: formValue.personalData?.lastname?.trim() ?? '',
+            dni: formValue.personalData?.dni?.trim() ?? '',
+            phone: formValue.personalData?.phone?.trim() ?? ''
+        };
+
+        this.usersService.createUser(payload).subscribe({
+            next: () => {
+                this.messageService.add({
+                    severity: 'success',
+                    summary: 'Éxito',
+                    detail: 'Usuario creado correctamente',
+                    life: 3000
+                });
+                this.hideDialog();
+                this.reloadUsers(true);
+            },
+            error: () => {
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'No se pudo crear el usuario',
+                    life: 3000
+                });
+            }
+        });
+    }
+
+    hideDialog(): void {
+        this.userDialog = false;
+        this.isEditMode = false;
+        this.submitted = false;
+        this.selectedUser = null;
+        this.resetForm();
+        this.setPasswordValidators(false);
+    }
+
+    onSearch(event: Event): void {
+        const value = (event.target as HTMLInputElement)?.value ?? '';
+        this.searchValue = value;
+        this.search$.next(value);
+    }
+
+    clearSearch(): void {
+        this.searchValue = '';
+        this.search$.next('');
+    }
+
+    isInvalid(controlName: string): boolean {
+        const control = this.userForm.get(controlName);
+        return !!control && control.invalid && (control.dirty || control.touched || this.submitted);
+    }
+
+    private reloadUsers(resetToFirst: boolean = false): void {
+        const event: TableLazyLoadEvent = this.lastLazyEvent
+            ? { ...this.lastLazyEvent }
+            : { first: 0, rows: this.rows };
+
+        if (resetToFirst) {
+            event.first = 0;
+        }
+
+        this.loadUsers(event);
+    }
+
+    private resetForm(): void {
+        this.userForm.reset({
+            username: '',
+            email: '',
+            role: 'EMPLOYEE',
+            isFirstLogin: false,
+            password: ''
+        });
+
+        const personalDataGroup = this.userForm.get('personalData') as FormGroup;
+        personalDataGroup.reset({
+            name: '',
+            lastname: '',
+            dni: '',
+            phone: ''
+        });
+    }
+
+    private setPasswordValidators(required: boolean): void {
+        const passwordControl = this.userForm.get('password');
+        if (!passwordControl) {
+            return;
+        }
+
+        if (required) {
+            passwordControl.setValidators([Validators.required, Validators.minLength(8)]);
+        } else {
+            passwordControl.clearValidators();
+        }
+        passwordControl.updateValueAndValidity();
+    }
+
+    private buildPersonalData(data: PersonalData | null | undefined): PersonalData | null {
+        if (!data) {
+            return null;
+        }
+
+        const trimmed: PersonalData = {
+            name: data.name?.trim() || '',
+            lastname: data.lastname?.trim() || '',
+            dni: data.dni?.trim() || '',
+            phone: data.phone?.trim() || ''
+        };
+
+        const hasValue = Object.values(trimmed).some((value) => !!value);
+        return hasValue ? trimmed : null;
+    }
 }

--- a/src/app/pages/service/users.service.ts
+++ b/src/app/pages/service/users.service.ts
@@ -1,0 +1,75 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment';
+
+export interface PersonalData {
+    name?: string;
+    lastname?: string;
+    dni?: string;
+    phone?: string;
+}
+
+export interface User {
+    _id: string;
+    username: string;
+    email: string;
+    role: 'ADMIN' | 'EMPLOYEE' | string;
+    isFirstLogin?: boolean;
+    personalData?: PersonalData | null;
+}
+
+export interface PaginatedResponse<T> {
+    data: T[];
+    total: number;
+    page: number;
+    limit: number;
+}
+
+export interface CreateUserPayload {
+    username: string;
+    email: string;
+    password: string;
+    name?: string;
+    lastname?: string;
+    dni?: string;
+    phone?: string;
+}
+
+export interface UpdateUserPayload {
+    username?: string;
+    email?: string;
+    role?: string;
+    isFirstLogin?: boolean;
+    personalData?: PersonalData | null;
+}
+
+@Injectable()
+export class UsersService {
+    private readonly apiUrl = environment.backendUrl;
+    private readonly usersEndpoint = `${this.apiUrl}/private/users`;
+    private readonly registerEndpoint = `${this.apiUrl}/auth/register`;
+
+    constructor(private readonly http: HttpClient) {}
+
+    getUsers(page: number = 1, limit: number = 10, search?: string) {
+        let params = new HttpParams().set('page', page).set('limit', limit);
+
+        if (search && search.trim().length > 0) {
+            params = params.set('search', search.trim());
+        }
+
+        return this.http.get<PaginatedResponse<User>>(this.usersEndpoint, { params });
+    }
+
+    createUser(payload: CreateUserPayload) {
+        return this.http.post<User>(this.registerEndpoint, payload);
+    }
+
+    updateUser(userId: string, payload: UpdateUserPayload) {
+        return this.http.patch<User>(`${this.usersEndpoint}/${userId}`, payload);
+    }
+
+    deleteUser(userId: string) {
+        return this.http.delete<void>(`${this.usersEndpoint}/${userId}`);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the admin users placeholder with a PrimeNG table that supports lazy loading, pagination, search, and CRUD actions
- add reactive dialog forms for creating and editing users with validation, confirmation, and toast notifications
- introduce a typed UsersService for backend integration including paginated listing, create, update, and delete endpoints

## Testing
- npm run build *(fails: font inlining requires a remote fetch that returns 403 in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cab7c42bc8832b98fffb763ef142c6