### PR TITLE
Add modern case lookup UI for view-complaint

### DIFF
--- a/src/app/pages/view-complaint/view-complaint.html
+++ b/src/app/pages/view-complaint/view-complaint.html
@@ -8,19 +8,30 @@
         <form [formGroup]="searchForm" (ngSubmit)="onSearch()" class="search-form" novalidate>
             <div class="input-group">
                 <label for="caseNumber">Número de caso</label>
-                <div class="input-wrapper" [class.input-invalid]="searchForm.controls.caseNumber.invalid && (searchForm.controls.caseNumber.dirty || searchForm.controls.caseNumber.touched)">
-                    <input id="caseNumber" type="text" formControlName="caseNumber" placeholder="Ej. FB-250909-224953" autocomplete="off" inputmode="text" aria-describedby="caseNumberHelp" />
+                <div class="input-wrapper"
+                    [class.input-invalid]="searchForm.controls.caseNumber.invalid && (searchForm.controls.caseNumber.dirty || searchForm.controls.caseNumber.touched)">
+                    <input id="caseNumber" type="text" formControlName="caseNumber" placeholder="Ej. FB-250909-224953"
+                        autocomplete="off" inputmode="text" aria-describedby="caseNumberHelp" />
                 </div>
-                <small id="caseNumberHelp" class="input-hint"> Ingresa el número tal como aparece en el correo de confirmación. </small>
-                <small class="input-error" *ngIf="searchForm.controls.caseNumber.hasError('required') && (searchForm.controls.caseNumber.dirty || searchForm.controls.caseNumber.touched)"> El número de caso es obligatorio. </small>
-                <small class="input-error" *ngIf="(searchForm.controls.caseNumber.hasError('minlength') || searchForm.controls.caseNumber.hasError('pattern')) && (searchForm.controls.caseNumber.dirty || searchForm.controls.caseNumber.touched)">
+                <small id="caseNumberHelp" class="input-hint"> Ingresa el número tal como aparece en el correo de
+                    confirmación. </small>
+                <small class="input-error"
+                    *ngIf="searchForm.controls.caseNumber.hasError('required') && (searchForm.controls.caseNumber.dirty || searchForm.controls.caseNumber.touched)">
+                    El número de caso es obligatorio. </small>
+                <small class="input-error"
+                    *ngIf="(searchForm.controls.caseNumber.hasError('minlength') || searchForm.controls.caseNumber.hasError('pattern')) && (searchForm.controls.caseNumber.dirty || searchForm.controls.caseNumber.touched)">
                     Verifica que el formato del caso sea válido.
                 </small>
             </div>
 
-            <button type="submit" [disabled]="searchForm.invalid || loading" class="search-button">
+            <button class="search-button" pButton pRipple type="submit" [disabled]="searchForm.invalid || loading" [rounded]="true"
+                [text]="true">
                 <ng-container *ngIf="!loading; else loadingLabel">Buscar</ng-container>
             </button>
+
+            <button class="search-button" pButton pRipple label="Cancelar" routerLink="/" [rounded]="true" [text]="true" severity="danger">
+            </button>
+
             <ng-template #loadingLabel>
                 <span class="loading-content">
                     <span class="loader" aria-hidden="true"></span>
@@ -30,13 +41,15 @@
         </form>
 
         <p class="feedback-message error" *ngIf="errorMessage">{{ errorMessage }}</p>
-        <p class="feedback-message muted" *ngIf="notFound && !errorMessage">No se encontró ningún caso con ese número.</p>
+        <p class="feedback-message muted" *ngIf="notFound && !errorMessage">No se encontró ningún caso con ese número.
+        </p>
     </section>
 
     <section class="result-section" *ngIf="feedback as case">
         <article class="feedback-card glass-card">
             <header class="card-header">
-                <div class="status-badge" [ngClass]="getStatusClass(case.status)">{{ getStatusLabel(case.status) }}</div>
+                <div class="status-badge" [ngClass]="getStatusClass(case.status)">{{ getStatusLabel(case.status) }}
+                </div>
                 <div class="case-identifiers">
                     <span class="case-label">Caso</span>
                     <span class="case-number">{{ case.caseNumber }}</span>

--- a/src/app/pages/view-complaint/view-complaint.html
+++ b/src/app/pages/view-complaint/view-complaint.html
@@ -1,1 +1,83 @@
-<p>view-complaint works!</p>
+<div class="view-complaint-page">
+    <section class="search-panel glass-card">
+        <div class="search-header">
+            <h1>Buscador de casos</h1>
+            <p>Consulta el estado de tu reporte ingresando el número de caso asignado.</p>
+        </div>
+
+        <form [formGroup]="searchForm" (ngSubmit)="onSearch()" class="search-form" novalidate>
+            <div class="input-group">
+                <label for="caseNumber">Número de caso</label>
+                <div class="input-wrapper" [class.input-invalid]="searchForm.controls.caseNumber.invalid && (searchForm.controls.caseNumber.dirty || searchForm.controls.caseNumber.touched)">
+                    <input id="caseNumber" type="text" formControlName="caseNumber" placeholder="Ej. FB-250909-224953" autocomplete="off" inputmode="text" aria-describedby="caseNumberHelp" />
+                </div>
+                <small id="caseNumberHelp" class="input-hint"> Ingresa el número tal como aparece en el correo de confirmación. </small>
+                <small class="input-error" *ngIf="searchForm.controls.caseNumber.hasError('required') && (searchForm.controls.caseNumber.dirty || searchForm.controls.caseNumber.touched)"> El número de caso es obligatorio. </small>
+                <small class="input-error" *ngIf="(searchForm.controls.caseNumber.hasError('minlength') || searchForm.controls.caseNumber.hasError('pattern')) && (searchForm.controls.caseNumber.dirty || searchForm.controls.caseNumber.touched)">
+                    Verifica que el formato del caso sea válido.
+                </small>
+            </div>
+
+            <button type="submit" [disabled]="searchForm.invalid || loading" class="search-button">
+                <ng-container *ngIf="!loading; else loadingLabel">Buscar</ng-container>
+            </button>
+            <ng-template #loadingLabel>
+                <span class="loading-content">
+                    <span class="loader" aria-hidden="true"></span>
+                    Buscando...
+                </span>
+            </ng-template>
+        </form>
+
+        <p class="feedback-message error" *ngIf="errorMessage">{{ errorMessage }}</p>
+        <p class="feedback-message muted" *ngIf="notFound && !errorMessage">No se encontró ningún caso con ese número.</p>
+    </section>
+
+    <section class="result-section" *ngIf="feedback as case">
+        <article class="feedback-card glass-card">
+            <header class="card-header">
+                <div class="status-badge" [ngClass]="getStatusClass(case.status)">{{ getStatusLabel(case.status) }}</div>
+                <div class="case-identifiers">
+                    <span class="case-label">Caso</span>
+                    <span class="case-number">{{ case.caseNumber }}</span>
+                </div>
+            </header>
+
+            <div class="card-body">
+                <div class="profile">
+                    <div class="avatar" aria-hidden="true">{{ getInitials(case) }}</div>
+                    <div class="profile-info">
+                        <h2>{{ getFullName(case) }}</h2>
+                        <p class="contact" *ngIf="case.email">
+                            <span class="icon" aria-hidden="true">✉️</span>
+                            {{ case.email }}
+                        </p>
+                        <p class="contact" *ngIf="case.phone">
+                            <span class="icon" aria-hidden="true">📞</span>
+                            {{ case.phone }}
+                        </p>
+                    </div>
+                </div>
+
+                <div class="info-grid">
+                    <div class="info-block">
+                        <h3>Descripción del caso</h3>
+                        <p>{{ case.description || 'Sin descripción disponible.' }}</p>
+                    </div>
+                    <div class="info-block">
+                        <h3>Dirección</h3>
+                        <p>{{ case.address || 'Sin dirección registrada.' }}</p>
+                    </div>
+                    <div class="info-block">
+                        <h3>Fecha de registro</h3>
+                        <p>{{ formatDate(case.dateRegister) }}</p>
+                    </div>
+                </div>
+
+                <div class="image-wrapper" *ngIf="case.attachmentUrl">
+                    <img [src]="case.attachmentUrl" alt="Imagen adjunta al caso" loading="lazy" />
+                </div>
+            </div>
+        </article>
+    </section>
+</div>

--- a/src/app/pages/view-complaint/view-complaint.scss
+++ b/src/app/pages/view-complaint/view-complaint.scss
@@ -1,0 +1,379 @@
+:host {
+    display: block;
+    min-height: 100vh;
+    background: linear-gradient(135deg, #f5f7fb 0%, #eef2ff 100%);
+}
+
+.view-complaint-page {
+    min-height: inherit;
+    padding: clamp(2rem, 6vw, 4rem);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(1.5rem, 4vw, 3rem);
+    color: #1f2937;
+    font-family:
+        'Inter',
+        'Segoe UI',
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        'Helvetica Neue',
+        sans-serif;
+}
+
+.glass-card {
+    width: min(100%, 960px);
+    border-radius: 24px;
+    padding: clamp(1.75rem, 4vw, 2.75rem);
+    background: rgba(255, 255, 255, 0.82);
+    box-shadow:
+        0 30px 50px -25px rgba(15, 23, 42, 0.35),
+        inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(18px);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.search-panel {
+    text-align: left;
+}
+
+.search-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.search-header h1 {
+    font-size: clamp(1.75rem, 3vw, 2.4rem);
+    font-weight: 700;
+    color: #0f172a;
+    margin: 0;
+}
+
+.search-header p {
+    margin: 0;
+    color: #475569;
+    font-size: clamp(1rem, 1.5vw, 1.1rem);
+}
+
+.search-form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.input-group {
+    flex: 1 1 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.input-group label {
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    background: rgba(238, 242, 255, 0.7);
+    border-radius: 16px;
+    border: 1px solid transparent;
+    transition:
+        border-color 0.2s ease,
+        box-shadow 0.2s ease;
+}
+
+.input-wrapper:focus-within {
+    border-color: rgba(99, 102, 241, 0.5);
+    box-shadow: 0 10px 25px -15px rgba(99, 102, 241, 0.6);
+}
+
+.input-wrapper.input-invalid {
+    border-color: rgba(248, 113, 113, 0.7);
+}
+
+.input-wrapper input {
+    flex: 1;
+    padding: 0.85rem 1.15rem;
+    border: none;
+    background: transparent;
+    font-size: 1rem;
+    font-weight: 500;
+    color: inherit;
+    outline: none;
+}
+
+.input-wrapper input::placeholder {
+    color: rgba(100, 116, 139, 0.7);
+}
+
+.input-hint {
+    color: #64748b;
+    font-size: 0.85rem;
+}
+
+.input-error {
+    color: #e11d48;
+    font-size: 0.85rem;
+}
+
+.search-button {
+    flex-shrink: 0;
+    border: none;
+    border-radius: 18px;
+    padding: 0.95rem 2.5rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+    color: white;
+    cursor: pointer;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        filter 0.2s ease;
+}
+
+.search-button:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 30px -20px rgba(99, 102, 241, 0.8);
+}
+
+.search-button:disabled {
+    cursor: not-allowed;
+    filter: grayscale(0.3);
+    opacity: 0.7;
+}
+
+.loading-content {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.loader {
+    width: 1.1rem;
+    height: 1.1rem;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    border-top-color: white;
+    animation: spin 0.75s linear infinite;
+}
+
+.feedback-message {
+    margin-top: 1.25rem;
+    font-size: 0.95rem;
+}
+
+.feedback-message.error {
+    color: #dc2626;
+}
+
+.feedback-message.muted {
+    color: #475569;
+}
+
+.result-section {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.feedback-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.card-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    text-align: center;
+}
+
+.status-badge {
+    padding: 0.6rem 1.5rem;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 1.05rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #111827;
+    background: #f1f5f9;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.status-pending {
+    background: rgba(250, 204, 21, 0.18);
+    color: #92400e;
+    border: 1px solid rgba(250, 204, 21, 0.4);
+}
+
+.status-resolved {
+    background: rgba(16, 185, 129, 0.18);
+    color: #065f46;
+    border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.status-cancel {
+    background: rgba(248, 113, 113, 0.18);
+    color: #b91c1c;
+    border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.status-in-progress {
+    background: rgba(96, 165, 250, 0.18);
+    color: #1d4ed8;
+    border: 1px solid rgba(96, 165, 250, 0.35);
+}
+
+.status-unknown {
+    background: rgba(203, 213, 225, 0.6);
+    color: #0f172a;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.case-identifiers {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    color: #475569;
+}
+
+.case-label {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.75rem;
+}
+
+.case-number {
+    font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.profile {
+    display: flex;
+    gap: 1.25rem;
+    align-items: center;
+}
+
+.avatar {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+    color: white;
+    font-weight: 700;
+    font-size: 1.2rem;
+    display: grid;
+    place-items: center;
+    box-shadow: 0 15px 25px -20px rgba(99, 102, 241, 0.9);
+}
+
+.profile-info h2 {
+    margin: 0;
+    font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+    color: #0f172a;
+}
+
+.contact {
+    margin: 0.35rem 0 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #475569;
+}
+
+.contact .icon {
+    font-size: 1rem;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.info-block {
+    padding: 1.25rem;
+    border-radius: 18px;
+    background: rgba(248, 250, 255, 0.9);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.info-block h3 {
+    margin: 0;
+    font-size: 1rem;
+    color: #1e293b;
+    font-weight: 600;
+}
+
+.info-block p {
+    margin: 0;
+    color: #475569;
+    line-height: 1.5;
+}
+
+.image-wrapper {
+    border-radius: 20px;
+    overflow: hidden;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(15, 23, 42, 0.02);
+    max-height: 360px;
+}
+
+.image-wrapper img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (max-width: 768px) {
+    :host {
+        background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+    }
+
+    .search-form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .search-button {
+        width: 100%;
+    }
+
+    .profile {
+        align-items: flex-start;
+    }
+
+    .avatar {
+        width: 56px;
+        height: 56px;
+        font-size: 1rem;
+    }
+}

--- a/src/app/pages/view-complaint/view-complaint.scss
+++ b/src/app/pages/view-complaint/view-complaint.scss
@@ -58,7 +58,6 @@
 }
 
 .search-form {
-    display: flex;
     flex-wrap: wrap;
     align-items: flex-end;
     gap: 1rem;
@@ -124,30 +123,7 @@
 }
 
 .search-button {
-    flex-shrink: 0;
-    border: none;
-    border-radius: 18px;
-    padding: 0.95rem 2.5rem;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
-    color: white;
-    cursor: pointer;
-    transition:
-        transform 0.2s ease,
-        box-shadow 0.2s ease,
-        filter 0.2s ease;
-}
-
-.search-button:hover:not(:disabled) {
-    transform: translateY(-2px);
-    box-shadow: 0 20px 30px -20px rgba(99, 102, 241, 0.8);
-}
-
-.search-button:disabled {
-    cursor: not-allowed;
-    filter: grayscale(0.3);
-    opacity: 0.7;
+    margin-top: 1.25rem;
 }
 
 .loading-content {

--- a/src/app/pages/view-complaint/view-complaint.ts
+++ b/src/app/pages/view-complaint/view-complaint.ts
@@ -1,11 +1,260 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { firstValueFrom } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+type KnownStatus = 'PENDING' | 'RESOLVED' | 'IN_PROGRESS' | 'CANCEL';
+
+interface ViewFeedback {
+    caseNumber: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+    phone: string | null;
+    description: string | null;
+    address: string | null;
+    dateRegister: string | null;
+    status: string | null;
+    attachmentUrl: string | null;
+}
 
 @Component({
-  selector: 'app-view-complaint',
-  imports: [],
-  templateUrl: './view-complaint.html',
-  styleUrl: './view-complaint.scss'
+    selector: 'app-view-complaint',
+    standalone: true,
+    imports: [CommonModule, ReactiveFormsModule],
+    templateUrl: './view-complaint.html',
+    styleUrl: './view-complaint.scss'
 })
 export class ViewComplaint {
+    private readonly http = inject(HttpClient);
+    private readonly fb = inject(FormBuilder);
+    private readonly backendUrl = environment.backendUrl;
 
+    readonly searchForm = this.fb.nonNullable.group({
+        caseNumber: ['', [Validators.required, Validators.pattern(/^[A-Za-z0-9-]+$/), Validators.minLength(5)]]
+    });
+
+    readonly statusLabels: Record<KnownStatus, string> = {
+        PENDING: 'Pendiente',
+        RESOLVED: 'Resuelto',
+        IN_PROGRESS: 'En progreso',
+        CANCEL: 'Cancelado'
+    };
+
+    loading = false;
+    notFound = false;
+    errorMessage = '';
+    feedback: ViewFeedback | null = null;
+
+    async onSearch() {
+        if (this.searchForm.invalid) {
+            this.searchForm.markAllAsTouched();
+            return;
+        }
+
+        this.loading = true;
+        this.notFound = false;
+        this.errorMessage = '';
+        this.feedback = null;
+
+        const caseNumber = this.searchForm.controls.caseNumber.value.trim();
+
+        try {
+            const response = await firstValueFrom(
+                this.http.post(`${this.backendUrl}/public/feedback/view-feedback`, {
+                    caseNumber
+                })
+            );
+
+            const feedback = this.mapFeedback(response, caseNumber);
+            if (feedback) {
+                this.feedback = feedback;
+                return;
+            }
+
+            this.notFound = true;
+        } catch (error) {
+            if (error instanceof HttpErrorResponse && error.status === 404) {
+                this.notFound = true;
+                return;
+            }
+
+            this.errorMessage = 'No se pudo obtener la información del caso. Inténtalo nuevamente más tarde.';
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    getStatusClass(status: string | null): string {
+        const normalized = (status ?? 'unknown').toLowerCase();
+        return `status-${normalized.replace(/[\s_]+/g, '-')}`;
+    }
+
+    getStatusLabel(status: string | null): string {
+        const normalized = (status ?? '').toUpperCase() as KnownStatus;
+        return this.statusLabels[normalized] ?? status ?? 'Sin estado';
+    }
+
+    getFullName(feedback: ViewFeedback): string {
+        const parts = [feedback.firstName, feedback.lastName].filter(Boolean);
+        return parts.length ? parts.join(' ') : 'Nombre no disponible';
+    }
+
+    getInitials(feedback: ViewFeedback): string {
+        const initials = [feedback.firstName, feedback.lastName]
+            .map((part) => part?.trim().charAt(0) ?? '')
+            .join('')
+            .toUpperCase();
+
+        return initials || 'FB';
+    }
+
+    formatDate(dateValue: string | null): string {
+        if (!dateValue) {
+            return 'Sin fecha disponible';
+        }
+
+        const parsed = new Date(dateValue);
+        if (Number.isNaN(parsed.getTime())) {
+            return dateValue;
+        }
+
+        return new Intl.DateTimeFormat('es-PE', {
+            dateStyle: 'long',
+            timeStyle: 'short'
+        }).format(parsed);
+    }
+
+    private mapFeedback(response: unknown, fallbackCaseNumber: string): ViewFeedback | null {
+        if (!response || typeof response !== 'object') {
+            return null;
+        }
+
+        const candidate = this.unwrapResponse(response);
+        if (!candidate || typeof candidate !== 'object') {
+            return null;
+        }
+
+        const firstName = this.toNullableString((candidate as any).firstName) ?? '';
+        const lastName = this.toNullableString((candidate as any).lastName) ?? '';
+        const caseNumber = this.toNullableString((candidate as any).caseNumber) ?? fallbackCaseNumber ?? '';
+
+        const feedback: ViewFeedback = {
+            caseNumber,
+            firstName,
+            lastName,
+            email: this.toNullableString((candidate as any).email),
+            phone: this.toNullableString((candidate as any).phone ?? (candidate as any).telephone ?? (candidate as any).mobile),
+            description: this.toNullableString((candidate as any).description ?? (candidate as any).detail ?? (candidate as any).message),
+            address: this.composeAddress((candidate as any).address ?? (candidate as any).addressLine ?? (candidate as any).location),
+            dateRegister: this.toNullableString((candidate as any).dateRegister ?? (candidate as any).createdAt ?? (candidate as any).updatedAt) ?? null,
+            status: this.toNullableString((candidate as any).status)?.toUpperCase() ?? null,
+            attachmentUrl: this.resolveAttachmentUrl((candidate as any).attachment ?? (candidate as any).image ?? (candidate as any).attachmentUrl)
+        };
+        return feedback;
+    }
+
+    private unwrapResponse(response: any): any {
+        if (!response || typeof response !== 'object') {
+            return null;
+        }
+
+        if (response.data && typeof response.data === 'object') {
+            return response.data;
+        }
+
+        if (response.feedback && typeof response.feedback === 'object') {
+            return response.feedback;
+        }
+
+        return response;
+    }
+
+    private toNullableString(value: unknown): string | null {
+        if (value === null || value === undefined) {
+            return null;
+        }
+
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            return trimmed ? trimmed : null;
+        }
+
+        if (typeof value === 'number' || typeof value === 'boolean') {
+            return String(value);
+        }
+
+        return null;
+    }
+
+    private composeAddress(raw: unknown): string | null {
+        if (!raw) {
+            return null;
+        }
+
+        if (typeof raw === 'string') {
+            return raw.trim() || null;
+        }
+
+        if (Array.isArray(raw)) {
+            const parts = raw.map((value) => this.toNullableString(value)).filter((value): value is string => !!value);
+            return parts.length ? Array.from(new Set(parts)).join(', ') : null;
+        }
+
+        if (typeof raw === 'object') {
+            const addressObj = raw as Record<string, unknown>;
+            const preferredOrder = ['addressLine', 'streetA', 'streetB', 'district', 'city', 'state', 'province', 'country', 'postalCode', 'zipCode', 'reference'];
+
+            const parts: string[] = [];
+            for (const key of preferredOrder) {
+                const value = this.toNullableString(addressObj[key]);
+                if (value && !parts.includes(value)) {
+                    parts.push(value);
+                }
+            }
+
+            if (!parts.length) {
+                const fallback = Object.values(addressObj)
+                    .map((value) => this.toNullableString(value))
+                    .filter((value): value is string => !!value);
+                return fallback.length ? Array.from(new Set(fallback)).join(', ') : null;
+            }
+
+            return parts.join(', ');
+        }
+
+        return null;
+    }
+
+    private resolveAttachmentUrl(raw: unknown): string | null {
+        if (!raw) {
+            return null;
+        }
+
+        if (typeof raw === 'string') {
+            const trimmed = raw.trim();
+            return trimmed ? this.ensureAbsoluteUrl(trimmed) : null;
+        }
+
+        if (typeof raw === 'object') {
+            const candidateUrl = this.toNullableString((raw as any).url ?? (raw as any).path ?? (raw as any).secure_url ?? (raw as any).location);
+            return candidateUrl ? this.ensureAbsoluteUrl(candidateUrl) : null;
+        }
+
+        return null;
+    }
+
+    private ensureAbsoluteUrl(url: string): string {
+        if (/^https?:\/\//i.test(url)) {
+            return url;
+        }
+
+        if (url.startsWith('/')) {
+            return `${this.backendUrl}${url}`;
+        }
+
+        return `${this.backendUrl}/${url}`;
+    }
 }

--- a/src/app/pages/view-complaint/view-complaint.ts
+++ b/src/app/pages/view-complaint/view-complaint.ts
@@ -2,6 +2,8 @@ import { CommonModule } from '@angular/common';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Component, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
 import { firstValueFrom } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
@@ -23,7 +25,7 @@ interface ViewFeedback {
 @Component({
     selector: 'app-view-complaint',
     standalone: true,
-    imports: [CommonModule, ReactiveFormsModule],
+    imports: [CommonModule, ReactiveFormsModule, RouterLink, ButtonModule],
     templateUrl: './view-complaint.html',
     styleUrl: './view-complaint.scss'
 })


### PR DESCRIPTION
## Summary
- implement a case number search form that queries the public feedback endpoint and handles errors
- render the returned feedback inside a highlighted status card with formatted details and attachment support
- refresh the view-complaint styles with a glassmorphism-inspired, responsive layout

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/icon?family=Material+Icons returned status code: 403.)*

------
https://chatgpt.com/codex/tasks/task_e_68cb272e1824832b8a90852b662aebb7