### PR TITLE
feat: redesign complaints admin view with cards

### DIFF
--- a/src/app/pages/admin/complaints/complaints.html
+++ b/src/app/pages/admin/complaints/complaints.html
@@ -31,7 +31,8 @@
                 <div class="card-body">
                     <div class="card-heading">
                         <div class="card-heading-info">
-                            <h3>{{ complaint.firstName }} {{ complaint.lastName }}</h3>
+                            <h3> {{complaint.caseNumber}} </h3>
+                            <span> {{ complaint.firstName }} {{ complaint.lastName }}</span>
                             <span class="type-chip" [ngClass]="getTypeClass(complaint.type)">
                                 {{ getTypeDescription(complaint.type) }}
                             </span>

--- a/src/app/pages/admin/complaints/complaints.html
+++ b/src/app/pages/admin/complaints/complaints.html
@@ -1,60 +1,140 @@
-<p-table #dt [value]="complaints()" [columns]="cols" [paginator]="true" [rows]="10" [totalRecords]="totalRecords"
-    [lazy]="true" (onLazyLoad)="loadComplaintsLazy($event)" dataKey="_id"
-    currentPageReportTemplate="Del {first} al {last} de {totalRecords} quejas" [showCurrentPageReport]="true"
-    [rowsPerPageOptions]="[10, 20, 30]">
-    <ng-template #caption>
-        <div class="flex items-center justify-between">
-            <h5 class="m-0">Denuncias, Quejas o Sugerencias Ciudadanas</h5>
-            <p-iconfield>
-                <p-inputicon styleClass="pi pi-search" />
-                <input pInputText type="text" (input)="onGlobalFilter(dt, $event)" placeholder="Search..." />
-            </p-iconfield>
+<div class="complaints-page">
+    <div class="page-header">
+        <div class="page-title">
+            <h2>Denuncias, Quejas o Sugerencias Ciudadanas</h2>
+            <p>Administra los casos recibidos y da seguimiento a su estado.</p>
+        </div>
+        <p-iconfield class="search-field">
+            <p-inputicon styleClass="pi pi-search" />
+            <input pInputText type="text" placeholder="Buscar por nombre, estado o detalle"
+                [value]="searchTerm()" (input)="onSearch($event)" />
+        </p-iconfield>
+    </div>
+
+    <div class="results-summary">
+        <span>Mostrando {{ filteredComplaints().length }} de {{ totalRecords }} registros</span>
+    </div>
+
+    <ng-container *ngIf="filteredComplaints().length; else emptyState">
+        <div class="complaints-grid">
+            <article class="complaint-card" *ngFor="let complaint of filteredComplaints(); trackBy: trackById">
+                <div class="card-media" [class.clickable]="getAttachmentUrl(complaint)"
+                    (click)="openImageDialog(complaint)">
+                    <ng-container *ngIf="getAttachmentUrl(complaint) as imageUrl; else noImage">
+                        <img [src]="imageUrl" alt="Evidencia adjunta" />
+                    </ng-container>
+                    <ng-template #noImage>
+                        <p-avatar icon="pi pi-image" shape="circle" styleClass="placeholder-avatar" />
+                    </ng-template>
+                </div>
+
+                <div class="card-body">
+                    <div class="card-heading">
+                        <div class="card-heading-info">
+                            <h3>{{ complaint.firstName }} {{ complaint.lastName }}</h3>
+                            <span class="type-chip" [ngClass]="getTypeClass(complaint.type)">
+                                {{ getTypeDescription(complaint.type) }}
+                            </span>
+                        </div>
+                        <p-tag [value]="getDescriptionStatus(complaint.status)"
+                            [severity]="getSeverity(complaint.status)" />
+                    </div>
+
+                    <p class="card-description">
+                        {{ getShortDescription(complaint.description) }}
+                    </p>
+
+                    <div class="card-meta">
+                        <div class="meta-item">
+                            <i class="pi pi-envelope"></i>
+                            <span>{{ complaint.email || 'Sin correo registrado' }}</span>
+                        </div>
+                        <div class="meta-item">
+                            <i class="pi pi-phone"></i>
+                            <span>{{ complaint.phone || 'Sin teléfono registrado' }}</span>
+                        </div>
+                        <div class="meta-item">
+                            <i class="pi pi-calendar"></i>
+                            <span>{{ formatDate(complaint.dateRegister) }}</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card-actions">
+                    <p-button label="Ver" icon="pi pi-eye" severity="info" [outlined]="true" class="action-button"
+                        (click)="viewComplaints(complaint)" />
+                    <p-button label="Editar" icon="pi pi-pencil" [outlined]="true" class="action-button"
+                        (click)="editComplaints(complaint)" />
+                    <p-button label="Eliminar" icon="pi pi-trash" severity="danger" [outlined]="true"
+                        class="action-button" (click)="cancelFeedback(complaint)" />
+                </div>
+            </article>
+        </div>
+    </ng-container>
+
+    <ng-template #emptyState>
+        <div class="empty-state">
+            <i class="pi pi-inbox"></i>
+            <p>No se encontraron denuncias para mostrar.</p>
         </div>
     </ng-template>
-    <ng-template #header>
-        <tr>
-            <th style="min-width: 10rem">Imagen</th>
-            <th pSortableColumn="name" style="min-width: 10rem">Nombre</th>
-            <th pSortableColumn="category" style="min-width: 8rem">Apellido</th>
-            <th pSortableColumn="category" style="min-width: 8rem">Teléfono</th>
-            <th pSortableColumn="category" style="min-width: 8rem">Email</th>
-            <th pSortableColumn="name" style="min-width: 8rem">Tipo</th>
-            <th pSortableColumn="inventoryStatus" style="min-width: 12rem">Estado</th>
-            <th style="min-width: 12rem"></th>
-        </tr>
-    </ng-template>
-    <ng-template #body let-complaints>
-        <tr>
-            <td>
-                <ng-container *ngIf="getAttachmentUrl(complaints) as imageUrl; else noImage">
-                    <img [src]="imageUrl" alt="Evidencia" class="w-16 h-16 object-cover rounded cursor-pointer"
-                        (click)="openImageDialog(complaints)" />
-                </ng-container>
-                <ng-template #noImage>
-                    <span class="material-icons text-gray-400 text-4xl">image_not_supported</span>
-                </ng-template>
-            </td>
-            <td style="min-width: 10rem">{{ complaints.firstName }}</td>
-            <td>{{ complaints.lastName }}</td>
-            <td>{{ complaints.phone }}</td>
-            <td>{{ complaints.email }}</td>
-            <td [ngClass]="getTypeClass(complaints.type)">
-                {{ getTypeDescription(complaints.type) }}
-            </td>
-            <td>
-                <p-tag [value]="getDescriptionStatus(complaints.status)" [severity]="getSeverity(complaints.status)" />
-            </td>
-            <td>
-                <p-button icon="pi pi-pencil" class="mr-2" [rounded]="true" [outlined]="true"
-                    (click)="editComplaints(complaints)" />
-                <p-button icon="pi pi-trash" severity="danger" [rounded]="true" [outlined]="true"
-                    (click)="cancelFeedback(complaints)" />
-            </td>
-        </tr>
-    </ng-template>
-</p-table>
 
-<p-dialog [(visible)]="complaintsDialog" [style]="{ width: '450px' }" header="Detalle de la Queja" [modal]="true">
+    <p-paginator *ngIf="totalRecords > rowsPerPageOptions[0]" [first]="first" [rows]="rows"
+        [totalRecords]="totalRecords" [rowsPerPageOptions]="rowsPerPageOptions" (onPageChange)="onPageChange($event)" />
+</div>
+
+<p-dialog [(visible)]="viewDialogVisible" [style]="{ width: '520px' }" header="Detalle de la Queja" [modal]="true"
+    (onHide)="closeViewDialog()">
+    <ng-template #content>
+        <div *ngIf="viewFeedback as complaint" class="view-dialog">
+            <div class="view-dialog__status">
+                <p-tag [value]="getDescriptionStatus(complaint.status)"
+                    [severity]="getSeverity(complaint.status)" />
+                <span class="type-chip" [ngClass]="getTypeClass(complaint.type)">
+                    {{ getTypeDescription(complaint.type) }}
+                </span>
+            </div>
+
+            <div class="view-dialog__grid">
+                <div class="view-dialog__item">
+                    <span class="label">Denunciante</span>
+                    <span class="value">{{ complaint.firstName }} {{ complaint.lastName }}</span>
+                </div>
+                <div class="view-dialog__item">
+                    <span class="label">Correo</span>
+                    <span class="value">{{ complaint.email || 'Sin correo registrado' }}</span>
+                </div>
+                <div class="view-dialog__item">
+                    <span class="label">Teléfono</span>
+                    <span class="value">{{ complaint.phone || 'Sin teléfono registrado' }}</span>
+                </div>
+                <div class="view-dialog__item">
+                    <span class="label">Fecha de registro</span>
+                    <span class="value">{{ formatDate(complaint.dateRegister) }}</span>
+                </div>
+            </div>
+
+            <div class="view-dialog__description">
+                <span class="label">Descripción</span>
+                <p>{{ complaint.description || 'Sin descripción proporcionada.' }}</p>
+            </div>
+
+            <div class="view-dialog__attachment" *ngIf="getAttachmentUrl(complaint) as imageUrl">
+                <span class="label">Adjunto</span>
+                <div class="attachment-preview" (click)="openImageDialog(complaint)">
+                    <img [src]="imageUrl" alt="Adjunto de la denuncia" />
+                    <span>Ver imagen</span>
+                </div>
+            </div>
+        </div>
+    </ng-template>
+
+    <ng-template #footer>
+        <p-button label="Cerrar" icon="pi pi-times" text (click)="closeViewDialog()" />
+    </ng-template>
+</p-dialog>
+
+<p-dialog [(visible)]="complaintsDialog" [style]="{ width: '450px' }" header="Actualizar estado" [modal]="true">
     <ng-template #content>
         <div class="flex flex-col gap-6">
             <div>
@@ -68,7 +148,7 @@
                     readonly />
             </div>
             <div>
-                <label for="description" class="block font-bold mb-3">Description</label>
+                <label for="description" class="block font-bold mb-3">Descripción</label>
                 <textarea id="description" pTextarea [(ngModel)]="feedback.description" required rows="3" cols="20"
                     fluid readonly></textarea>
             </div>

--- a/src/app/pages/admin/complaints/complaints.scss
+++ b/src/app/pages/admin/complaints/complaints.scss
@@ -1,0 +1,400 @@
+:host {
+    display: block;
+    padding-bottom: 1rem;
+}
+
+.complaints-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: stretch;
+
+    .page-title {
+        h2 {
+            margin: 0;
+            font-size: 1.6rem;
+            font-weight: 600;
+            color: #111827;
+            letter-spacing: -0.015em;
+        }
+
+        p {
+            margin: 0.35rem 0 0;
+            color: #6b7280;
+            font-size: 0.95rem;
+        }
+    }
+
+    .search-field {
+        width: 100%;
+        max-width: 360px;
+        margin-left: auto;
+    }
+}
+
+.results-summary {
+    font-size: 0.95rem;
+    color: #6b7280;
+    text-align: right;
+}
+
+.complaints-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.75rem;
+}
+
+.complaint-card {
+    background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+    border-radius: 1.25rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: 0 20px 45px -25px rgba(15, 23, 42, 0.45);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+
+    &:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 25px 55px -25px rgba(30, 64, 175, 0.45);
+    }
+}
+
+.card-media {
+    position: relative;
+    height: 190px;
+    background: radial-gradient(circle at top, rgba(79, 70, 229, 0.08), rgba(59, 130, 246, 0.06));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+
+    &.clickable {
+        cursor: pointer;
+    }
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        transition: transform 0.3s ease;
+    }
+
+    &:hover img {
+        transform: scale(1.04);
+    }
+}
+
+.placeholder-avatar {
+    width: 4.5rem;
+    height: 4.5rem;
+    font-size: 1.75rem;
+    background: rgba(148, 163, 184, 0.25);
+    color: #64748b;
+}
+
+.card-body {
+    padding: 1.5rem 1.75rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.card-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+
+    h3 {
+        margin: 0;
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: #0f172a;
+    }
+}
+
+.card-heading-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.type-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background: rgba(148, 163, 184, 0.18);
+    color: #475569;
+}
+
+.type-chip--complaint {
+    background: rgba(239, 68, 68, 0.14);
+    color: #b91c1c;
+}
+
+.type-chip--suggestion {
+    background: rgba(59, 130, 246, 0.14);
+    color: #1d4ed8;
+}
+
+.type-chip--compliment {
+    background: rgba(34, 197, 94, 0.14);
+    color: #047857;
+}
+
+.type-chip--unknown {
+    background: rgba(148, 163, 184, 0.18);
+    color: #475569;
+}
+
+.card-description {
+    margin: 0;
+    color: #4b5563;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+
+    i {
+        font-size: 1rem;
+        color: #6366f1;
+    }
+}
+
+.card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0 1.75rem 1.75rem;
+}
+
+.empty-state {
+    margin-top: 2rem;
+    padding: 3rem 1.5rem;
+    border-radius: 1.25rem;
+    border: 1px dashed rgba(148, 163, 184, 0.5);
+    background: #f8fafc;
+    color: #94a3b8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+
+    i {
+        font-size: 2rem;
+        color: #94a3b8;
+    }
+
+    p {
+        margin: 0;
+        font-size: 1rem;
+    }
+}
+
+.view-dialog {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.view-dialog__status {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.view-dialog__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+}
+
+.view-dialog__item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    .label {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #94a3b8;
+    }
+
+    .value {
+        font-weight: 600;
+        color: #1f2937;
+    }
+}
+
+.view-dialog__description {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    .label {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #94a3b8;
+    }
+
+    p {
+        margin: 0;
+        color: #4b5563;
+        line-height: 1.6;
+    }
+}
+
+.view-dialog__attachment {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    .label {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #94a3b8;
+    }
+}
+
+.attachment-preview {
+    position: relative;
+    border-radius: 0.85rem;
+    overflow: hidden;
+    background: #0f172a;
+    cursor: pointer;
+
+    img {
+        width: 100%;
+        height: 190px;
+        object-fit: cover;
+        opacity: 0.92;
+        transition: opacity 0.3s ease;
+    }
+
+    span {
+        position: absolute;
+        right: 1rem;
+        bottom: 1rem;
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.75);
+        color: #f8fafc;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    &:hover img {
+        opacity: 1;
+    }
+}
+
+@media (min-width: 640px) {
+    .card-actions {
+        justify-content: flex-start;
+    }
+}
+
+@media (min-width: 768px) {
+    .page-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+
+        .page-title {
+            max-width: 60%;
+        }
+    }
+
+    .view-dialog__grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 639px) {
+    .card-actions {
+        flex-direction: column;
+    }
+
+    .results-summary {
+        text-align: left;
+    }
+}
+
+:host ::ng-deep .search-field .p-inputtext {
+    border-radius: 999px;
+    border: none;
+    background: #f3f4f6;
+    padding: 0.75rem 1rem 0.75rem 2.75rem;
+    box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.05);
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+    width: 100%;
+}
+
+:host ::ng-deep .search-field .p-inputtext:focus {
+    background: #ffffff;
+    box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.2);
+}
+
+:host ::ng-deep .card-heading .p-tag {
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.4rem 0.75rem;
+}
+
+:host ::ng-deep .card-actions .p-button {
+    flex: 1 1 140px;
+    border-radius: 999px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+:host ::ng-deep .card-actions .p-button:not(.p-button-text):hover {
+    transform: translateY(-2px);
+    box-shadow: 0 15px 30px -20px rgba(30, 64, 175, 0.65);
+}
+
+:host ::ng-deep .p-paginator {
+    margin-top: 1.5rem;
+    border: none;
+    background: transparent;
+    padding: 0;
+    justify-content: flex-end;
+}
+
+:host ::ng-deep .p-dialog .type-chip {
+    font-size: 0.7rem;
+}

--- a/src/app/pages/admin/complaints/complaints.scss
+++ b/src/app/pages/admin/complaints/complaints.scss
@@ -48,9 +48,13 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 1.75rem;
+    max-width: 1000px;
+    /* límite para que no se estire */
+    margin: 0 auto;
 }
 
 .complaint-card {
+    width: 300px;
     background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
     border-radius: 1.25rem;
     border: 1px solid rgba(148, 163, 184, 0.25);

--- a/src/app/pages/service/complaints.service.ts
+++ b/src/app/pages/service/complaints.service.ts
@@ -12,6 +12,7 @@ export interface Feedback {
     firstName: string;
     email: string;
     description: string;
+    caseNumber: string;
     phone: string;
     type: FeedbackType;
     contacted: boolean;


### PR DESCRIPTION
## Summary
- replace the complaints administration table with a responsive grid of modern cards that highlight description, media, status and key contact details
- add a detailed read-only dialog for viewing complaint information and keep edit/delete actions alongside the new layout
- enhance styling to deliver a polished PrimeNG-driven experience with responsive behaviour, status badges and attachment previews

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/icon?family=Material+Icons returned status code: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cb36491994832b857afcbac10a903d