### PR TITLE
Implement responsive heat map rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "@angular/router": "^20",
                 "@primeuix/themes": "^1.2.1",
                 "@tailwindcss/postcss": "^4.1.11",
+                "@types/google.maps": "^3.58.1",
                 "chart.js": "4.4.2",
                 "leaflet": "^1.9.4",
                 "leaflet.heat": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "@angular/router": "^20",
         "@primeuix/themes": "^1.2.1",
         "@tailwindcss/postcss": "^4.1.11",
+        "@types/google.maps": "^3.58.1",
         "chart.js": "4.4.2",
         "leaflet": "^1.9.4",
         "leaflet.heat": "^0.2.0",

--- a/src/app/pages/admin/heat-map/heat-map.component.html
+++ b/src/app/pages/admin/heat-map/heat-map.component.html
@@ -1,6 +1,4 @@
-<div class="card mb-8! heat-map-card">
+<div class="card mb-8!">
   <div class="font-semibold text-xl mb-4">Mapa de calor de feedbacks</div>
-  <div class="map-wrapper">
-    <div #mapContainer id="map" class="map-container" aria-label="Mapa de calor de feedbacks"></div>
-  </div>
+  <div id="gmap" class="map-container"></div>
 </div>

--- a/src/app/pages/admin/heat-map/heat-map.component.html
+++ b/src/app/pages/admin/heat-map/heat-map.component.html
@@ -1,4 +1,6 @@
-<div class="card mb-8!">
+<div class="card mb-8! heat-map-card">
   <div class="font-semibold text-xl mb-4">Mapa de calor de feedbacks</div>
-  <div id="map" style="height: 500px; border-radius: 8px; overflow: hidden;"></div>
+  <div class="map-wrapper">
+    <div #mapContainer id="map" class="map-container" aria-label="Mapa de calor de feedbacks"></div>
+  </div>
 </div>

--- a/src/app/pages/admin/heat-map/heat-map.component.scss
+++ b/src/app/pages/admin/heat-map/heat-map.component.scss
@@ -1,0 +1,34 @@
+:host {
+  display: block;
+}
+
+.heat-map-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.map-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+}
+
+.map-container {
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+:host ::ng-deep .leaflet-container {
+  width: 100% !important;
+  height: 100% !important;
+  font: inherit;
+}
+
+:host ::ng-deep .leaflet-control-attribution {
+  font-size: clamp(0.65rem, 1.5vw, 0.75rem);
+}

--- a/src/app/pages/admin/heat-map/heat-map.component.scss
+++ b/src/app/pages/admin/heat-map/heat-map.component.scss
@@ -1,34 +1,6 @@
-:host {
-  display: block;
-}
-
-.heat-map-card {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.map-wrapper {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  min-height: 320px;
-}
-
 .map-container {
+  height: 400px;
   width: 100%;
-  height: 100%;
-  min-height: 400px;
-  border-radius: 0.75rem;
+  border-radius: 8px;
   overflow: hidden;
-}
-
-:host ::ng-deep .leaflet-container {
-  width: 100% !important;
-  height: 100% !important;
-  font: inherit;
-}
-
-:host ::ng-deep .leaflet-control-attribution {
-  font-size: clamp(0.65rem, 1.5vw, 0.75rem);
 }

--- a/src/app/pages/admin/heat-map/heat-map.component.ts
+++ b/src/app/pages/admin/heat-map/heat-map.component.ts
@@ -1,99 +1,54 @@
+import { AfterViewInit, Component, OnDestroy } from '@angular/core';
 import { DashboardService } from '@/pages/service/dashboard.service';
-import { Component, AfterViewInit, ElementRef, OnDestroy, ViewChild } from '@angular/core';
-import * as L from 'leaflet';
-import 'leaflet.heat';
 
 @Component({
-    selector: 'app-heat-map',
-    standalone: true,
-    imports: [],
-    templateUrl: './heat-map.component.html',
-    styleUrl: './heat-map.component.scss'
+  selector: 'app-heat-map',
+  standalone: true,
+  templateUrl: './heat-map.component.html',
+  styleUrl: './heat-map.component.scss'
 })
 export class HeatMapComponent implements AfterViewInit, OnDestroy {
-    private readonly defaultCenter: L.LatLngTuple = [-0.1807, -78.4678];
-    private readonly defaultZoom = 12;
+  private map!: google.maps.Map;
+  private heatmap!: google.maps.visualization.HeatmapLayer;
 
-    @ViewChild('mapContainer', { static: true })
-    private mapContainer!: ElementRef<HTMLDivElement>;
+  constructor(private readonly dashboardService: DashboardService) {}
 
-    private map!: L.Map;
-    private heatLayer?: L.Layer;
-    private resizeObserver?: ResizeObserver;
+  ngAfterViewInit(): void {
+    this.initMap();
+    this.loadHeatmap();
+  }
 
-    constructor(private readonly dashboardService: DashboardService) { }
+  private initMap(): void {
+    const center = new google.maps.LatLng(-0.1807, -78.4678); // Quito
+    this.map = new google.maps.Map(document.getElementById('gmap') as HTMLElement, {
+      zoom: 12,
+      center,
+      mapTypeId: 'roadmap'
+    });
+  }
 
-    ngAfterViewInit(): void {
-        this.initializeMap();
-        this.observeResize();
-        this.loadFeedbacks();
+  private loadHeatmap(): void {
+    this.dashboardService.getAllFeedbacks().subscribe(feedbacks => {
+      const heatData = feedbacks.map(f => new google.maps.LatLng(f.latitude, f.longitude));
+
+      this.heatmap = new google.maps.visualization.HeatmapLayer({
+        data: heatData,
+        map: this.map,
+        radius: 25
+      });
+
+      // Ajustar el mapa a los puntos
+      if (heatData.length > 0) {
+        const bounds = new google.maps.LatLngBounds();
+        heatData.forEach(point => bounds.extend(point));
+        this.map.fitBounds(bounds);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.heatmap) {
+      this.heatmap.setMap(null);
     }
-
-    ngOnDestroy(): void {
-        this.resizeObserver?.disconnect();
-        this.map?.remove();
-    }
-
-    private initializeMap(): void {
-        this.map = L.map(this.mapContainer.nativeElement, {
-            zoomControl: true
-        }).setView(this.defaultCenter, this.defaultZoom);
-
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; OpenStreetMap contributors'
-        }).addTo(this.map);
-
-        // Ajusta inmediatamente después de la creación para evitar recortes.
-        setTimeout(() => this.map.invalidateSize(), 0);
-    }
-
-    private observeResize(): void {
-        if (typeof window === 'undefined' || typeof ResizeObserver === 'undefined' || !this.mapContainer) {
-            return;
-        }
-
-        this.resizeObserver = new ResizeObserver(() => {
-            if (this.map) {
-                this.map.invalidateSize();
-            }
-        });
-
-        this.resizeObserver.observe(this.mapContainer.nativeElement);
-    }
-
-    private loadFeedbacks(): void {
-        this.dashboardService.getAllFeedbacks().subscribe({
-            next: feedbacks => {
-                const heatData: [number, number, number][] = feedbacks
-                    .filter(f => typeof f.latitude === 'number' && typeof f.longitude === 'number')
-                    .map(f => [f.latitude, f.longitude, 0.6]);
-
-                if (this.heatLayer) {
-                    this.map.removeLayer(this.heatLayer);
-                }
-
-                if (heatData.length > 0) {
-                    this.heatLayer = (L as any).heatLayer(heatData, {
-                        radius: 28,
-                        blur: 18,
-                        maxZoom: 17,
-                        minOpacity: 0.35
-                    });
-                    this.heatLayer.addTo(this.map);
-
-                    const bounds = L.latLngBounds(heatData.map(([lat, lng]) => [lat, lng] as L.LatLngTuple));
-                    this.map.fitBounds(bounds.pad(0.1));
-                } else {
-                    this.map.setView(this.defaultCenter, this.defaultZoom);
-                }
-
-                // Asegura que el mapa se reajuste después de aplicar capas o bounds.
-                setTimeout(() => this.map.invalidateSize(), 0);
-            },
-            error: () => {
-                this.map.setView(this.defaultCenter, this.defaultZoom);
-                setTimeout(() => this.map.invalidateSize(), 0);
-            }
-        });
-    }
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,8 @@
     <link rel="icon" type="image/x-icon" href="https://primefaces.org/cdn/primeng/images/favicon.png" />
     <link href="https://fonts.cdnfonts.com/css/lato" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCYk6P2-xjdbZcUQI15gPCUsKUhnrkjXSs&libraries=places" async defer>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCYk6P2-xjdbZcUQI15gPCUsKUhnrkjXSs&libraries=visualization,places" async defer>
+
     </script>
 </head>
 


### PR DESCRIPTION
## Summary
- restructure the heat map card markup and styles to give the Leaflet container a responsive size
- initialize the Leaflet map through a ViewChild, manage the heat layer lifecycle, and fit bounds to feedback points
- observe container resizes and restore a default Quito view when no feedback data is returned

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: error TS18003: No inputs were found in config file '/workspace/complaints-suggestions-frontend/tsconfig.spec.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ce0d120bec832b9d5d05aae40f3ff9