### PR TITLE
feat: add loading indicators for authentication and feedback

### DIFF
--- a/src/app/pages/form-complaints/form-complaints.component.html
+++ b/src/app/pages/form-complaints/form-complaints.component.html
@@ -33,7 +33,7 @@
 
                         <div class="row end mt-5 mb-5">
                             <button pButton type="submit" label="Enviar" icon="pi pi-send"
-                                class="p-button-rounded pi-button-blue"></button>
+                                class="p-button-rounded pi-button-blue" [loading]="isSubmitting" [disabled]="isSubmitting"></button>
                         </div>
 
                         <div class="grid gap-2">


### PR DESCRIPTION
## Summary
- add a loading state to the login button and provide success and error toasts
- prevent duplicate complaint submissions by tracking the request state while showing button loading
- improve complaint submission feedback with clearer connectivity and authorization error messages

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/icon?family=Material+Icons returned status code: 403.)*


------
https://chatgpt.com/codex/tasks/task_e_68d2cbcc7558832b80a4101e30c40bc4