### PR TITLE
feat: add administrative roles management views

### DIFF
--- a/src/app/layout/component/app.menu.ts
+++ b/src/app/layout/component/app.menu.ts
@@ -32,6 +32,7 @@ export class AppMenu {
                     { label: 'Sugerencias', icon: 'pi pi-lightbulb', routerLink: ['/complaints/suggestions'] },
                     { label: 'Felicitaciones', icon: 'pi pi-heart', routerLink: ['/complaints/congratulations'] },
                     { label: 'Usuarios', icon: 'pi pi-fw pi-users', routerLink: ['/complaints/users'] },
+                    { label: 'Roles', icon: 'pi pi-id-card', routerLink: ['/complaints/roles'] },
                     { label: 'Empresas', icon: 'pi pi-fw pi-briefcase', routerLink: ['/complaints/companies'] },
                     /*{ label: 'Input', icon: 'pi pi-fw pi-check-square', routerLink: ['/uikit/input'] },
                     { label: 'Table', icon: 'pi pi-fw pi-table', routerLink: ['/uikit/table'] },

--- a/src/app/pages/admin/admin.routes.ts
+++ b/src/app/pages/admin/admin.routes.ts
@@ -5,12 +5,16 @@ import { Users } from './users/users';
 import { Companies } from './companies/companies';
 import { SuggestionsComponent } from './suggestions/suggestions.component';
 import { CongratulationsComponent } from './congratulations/congratulations.component';
+import { RolesComponent } from './roles/roles';
+import { RoleDetailComponent } from './roles/role-detail';
 
 export default [
     { path: 'complaints', data: { breadcrumb: 'Quejas' }, component: Complaints },
     { path: 'suggestions', data: { breadcrumb: 'Sugerencias' }, component: SuggestionsComponent },
     { path: 'congratulations', data: { breadcrumb: 'Felicitaciones' }, component: CongratulationsComponent },
     { path: 'users', data: { breadcrumb: 'Usuarios' }, component: Users },
+    { path: 'roles', data: { breadcrumb: 'Roles' }, component: RolesComponent },
+    { path: 'roles/:id', data: { breadcrumb: 'Detalle de rol' }, component: RoleDetailComponent },
     { path: 'companies', data: { breadcrumb: 'Empresas' }, component: Companies },
     { path: 'menu', data: { breadcrumb: 'Menu' }, component: MenuDemo },
     /*{ path: 'button', data: { breadcrumb: 'Button' }, component: ButtonDemo },

--- a/src/app/pages/admin/roles/role-detail.html
+++ b/src/app/pages/admin/roles/role-detail.html
@@ -1,0 +1,64 @@
+<div class="role-detail" *ngIf="!loading(); else loadingState">
+    <ng-container *ngIf="!error(); else errorState">
+        <p-card *ngIf="role() as currentRole" class="shadow-sm">
+            <ng-template #title>
+                <div class="flex items-center justify-between gap-4">
+                    <div>
+                        <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-0 m-0">
+                            {{ currentRole.name }}
+                        </h2>
+                        <p class="text-sm text-surface-500 dark:text-surface-400 m-0">
+                            Detalles completos del rol
+                        </p>
+                    </div>
+                    <p-tag [value]="getStatusLabel(currentRole.status)" [severity]="getStatusSeverity(currentRole.status)" />
+                </div>
+            </ng-template>
+
+            <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <div class="flex flex-col gap-2">
+                    <span class="text-sm font-semibold text-surface-500 dark:text-surface-400">Descripción</span>
+                    <p class="text-base text-surface-900 dark:text-surface-0 m-0">
+                        {{ currentRole.description || 'Sin descripción disponible.' }}
+                    </p>
+                </div>
+                <div class="flex flex-col gap-2">
+                    <span class="text-sm font-semibold text-surface-500 dark:text-surface-400">Estado</span>
+                    <p class="text-base text-surface-900 dark:text-surface-0 m-0">
+                        {{ getStatusLabel(currentRole.status) }}
+                    </p>
+                </div>
+                <div class="flex flex-col gap-2 md:col-span-2">
+                    <span class="text-sm font-semibold text-surface-500 dark:text-surface-400">Permisos asociados</span>
+                    <div class="flex flex-wrap gap-2">
+                        <p-tag
+                            *ngFor="let permission of currentRole.permissions || []"
+                            [value]="permission"
+                            severity="info"
+                        />
+                        <span *ngIf="!currentRole.permissions || !currentRole.permissions.length" class="text-surface-500 text-sm">
+                            Sin permisos asociados.
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex justify-end mt-6">
+                <p-button label="Volver" icon="pi pi-arrow-left" severity="secondary" (click)="goBack()" />
+            </div>
+        </p-card>
+    </ng-container>
+</div>
+
+<ng-template #loadingState>
+    <div class="flex items-center justify-center py-10">
+        <span class="text-surface-500">Cargando información del rol...</span>
+    </div>
+</ng-template>
+
+<ng-template #errorState>
+    <p-message severity="error" [text]="error() || ''"></p-message>
+    <div class="flex justify-end mt-4">
+        <p-button label="Volver" icon="pi pi-arrow-left" severity="secondary" (click)="goBack()" />
+    </div>
+</ng-template>

--- a/src/app/pages/admin/roles/role-detail.scss
+++ b/src/app/pages/admin/roles/role-detail.scss
@@ -1,0 +1,13 @@
+:host {
+    display: block;
+    width: 100%;
+}
+
+.role-detail {
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+p-card ::ng-deep .p-card-content {
+    padding-top: 0;
+}

--- a/src/app/pages/admin/roles/role-detail.ts
+++ b/src/app/pages/admin/roles/role-detail.ts
@@ -1,0 +1,73 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, computed, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { TagModule } from 'primeng/tag';
+import { MessageModule } from 'primeng/message';
+import { RolesService, Role } from '@/pages/service/roles.service';
+
+@Component({
+    selector: 'app-role-detail',
+    standalone: true,
+    templateUrl: './role-detail.html',
+    styleUrl: './role-detail.scss',
+    imports: [CommonModule, ButtonModule, CardModule, TagModule, MessageModule]
+})
+export class RoleDetailComponent implements OnInit {
+    readonly role = signal<Role | null>(null);
+    readonly loading = signal(true);
+    readonly error = signal<string | null>(null);
+
+    readonly statusLabel = computed(() => ({
+        ACT: 'Activo',
+        INA: 'Inactivo',
+        BLO: 'Bloqueado'
+    }));
+
+    readonly statusSeverity = computed(() => ({
+        ACT: 'success',
+        INA: 'warning',
+        BLO: 'danger'
+    }));
+
+    constructor(
+        private readonly route: ActivatedRoute,
+        private readonly router: Router,
+        private readonly rolesService: RolesService
+    ) {}
+
+    ngOnInit(): void {
+        const roleId = this.route.snapshot.paramMap.get('id');
+        if (!roleId) {
+            this.error.set('No se encontró el identificador del rol.');
+            this.loading.set(false);
+            return;
+        }
+
+        this.rolesService.findOne(roleId).subscribe({
+            next: (role) => {
+                this.role.set(role);
+                this.loading.set(false);
+            },
+            error: () => {
+                this.error.set('No se pudo cargar la información del rol.');
+                this.loading.set(false);
+            }
+        });
+    }
+
+    getStatusLabel(status?: string): string {
+        const map = this.statusLabel();
+        return map[status as keyof typeof map] ?? status ?? 'Desconocido';
+    }
+
+    getStatusSeverity(status?: string): string {
+        const map = this.statusSeverity();
+        return map[status as keyof typeof map] ?? 'info';
+    }
+
+    goBack(): void {
+        this.router.navigate(['/complaints/roles']);
+    }
+}

--- a/src/app/pages/admin/roles/roles.html
+++ b/src/app/pages/admin/roles/roles.html
@@ -1,0 +1,174 @@
+<p-toast />
+<p-confirmDialog />
+
+<p-table
+    [value]="roles()"
+    [lazy]="true"
+    [paginator]="true"
+    [rows]="rows"
+    [totalRecords]="totalRecords()"
+    (onLazyLoad)="loadRoles($event)"
+    [loading]="loading()"
+    dataKey="_id"
+    currentPageReportTemplate="Del {first} al {last} de {totalRecords} roles"
+    [showCurrentPageReport]="true"
+    [rowsPerPageOptions]="[5, 10, 20, 50]"
+    class="shadow-sm"
+>
+    <ng-template #caption>
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div class="flex flex-col gap-1">
+                <h2 class="text-lg font-semibold text-surface-900 dark:text-surface-0 m-0">
+                    Roles del sistema
+                </h2>
+                <p class="text-sm text-surface-500 dark:text-surface-400 m-0">
+                    Administra los roles y permisos disponibles.
+                </p>
+            </div>
+            <div class="flex flex-col gap-3 md:flex-row md:items-center">
+                <form [formGroup]="filtersForm" class="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+                    <p-iconfield class="w-full md:w-72">
+                        <p-inputicon styleClass="pi pi-search" />
+                        <input
+                            pInputText
+                            type="text"
+                            class="w-full"
+                            placeholder="Buscar roles"
+                            formControlName="search"
+                        />
+                    </p-iconfield>
+                    <p-select
+                        formControlName="status"
+                        [options]="statusOptions"
+                        optionLabel="label"
+                        optionValue="value"
+                        placeholder="Estado"
+                        class="w-full md:w-48"
+                    />
+                </form>
+                <p-button
+                    label="Nuevo rol"
+                    icon="pi pi-plus"
+                    class="p-button-rounded pi-button-blue w-full md:w-auto"
+                    (click)="openNew()"
+                />
+            </div>
+        </div>
+    </ng-template>
+
+    <ng-template #header>
+        <tr>
+            <th style="min-width: 12rem">Nombre</th>
+            <th style="min-width: 16rem">Descripción</th>
+            <th style="min-width: 8rem">Estado</th>
+            <th style="min-width: 16rem">Permisos</th>
+            <th style="width: 14rem">Acciones</th>
+        </tr>
+    </ng-template>
+
+    <ng-template #body let-role>
+        <tr>
+            <td>{{ role.name }}</td>
+            <td>{{ role.description || 'Sin descripción' }}</td>
+            <td>
+                <p-tag [value]="getStatusLabel(role.status)" [severity]="getStatusSeverity(role.status)" />
+            </td>
+            <td>
+                <div class="flex flex-wrap gap-2">
+                    <p-tag
+                        *ngFor="let permission of role.permissions || []"
+                        [value]="permission"
+                        severity="info"
+                    />
+                    <span *ngIf="!role.permissions || !role.permissions.length" class="text-surface-500 text-sm">
+                        Sin permisos
+                    </span>
+                </div>
+            </td>
+            <td>
+                <div class="flex flex-wrap gap-2">
+                    <p-button icon="pi pi-eye" [rounded]="true" outlined size="small" (click)="viewRole(role)" />
+                    <p-button icon="pi pi-pencil" [rounded]="true" outlined size="small" (click)="editRole(role)" />
+                    <p-button
+                        icon="pi pi-trash"
+                        severity="danger"
+                        [rounded]="true"
+                        outlined
+                        size="small"
+                        (click)="confirmDelete(role)"
+                    />
+                </div>
+            </td>
+        </tr>
+    </ng-template>
+
+    <ng-template #emptymessage>
+        <tr>
+            <td colspan="5" class="py-6 text-center text-surface-500 dark:text-surface-400">
+                No se encontraron roles.
+            </td>
+        </tr>
+    </ng-template>
+</p-table>
+
+<p-dialog
+    [(visible)]="roleDialog"
+    [modal]="true"
+    [style]="{ width: '40rem' }"
+    [breakpoints]="{ '960px': '90vw', '640px': '95vw' }"
+    [dismissableMask]="true"
+    (onHide)="hideDialog()"
+    [header]="isEditMode ? 'Editar rol' : 'Crear rol'"
+>
+    <ng-template #content>
+        <form [formGroup]="roleForm" (ngSubmit)="saveRole()" class="flex flex-col gap-4">
+            <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div class="md:col-span-2">
+                    <label for="name" class="block font-semibold mb-2">Nombre</label>
+                    <input id="name" type="text" pInputText formControlName="name" fluid />
+                    <small class="text-red-500" *ngIf="isInvalid('name')">
+                        El nombre es obligatorio.
+                    </small>
+                </div>
+                <div class="md:col-span-2">
+                    <label for="description" class="block font-semibold mb-2">Descripción</label>
+                    <textarea
+                        id="description"
+                        pTextarea
+                        formControlName="description"
+                        rows="3"
+                        class="w-full"
+                    ></textarea>
+                </div>
+                <div>
+                    <label for="status" class="block font-semibold mb-2">Estado</label>
+                    <p-select
+                        inputId="status"
+                        formControlName="status"
+                        [options]="statusOptions | slice:1"
+                        optionLabel="label"
+                        optionValue="value"
+                        placeholder="Seleccione un estado"
+                        class="w-full"
+                    />
+                </div>
+                <div>
+                    <label for="permissions" class="block font-semibold mb-2">Permisos</label>
+                    <p-multiSelect
+                        inputId="permissions"
+                        formControlName="permissions"
+                        [options]="permissionOptions"
+                        defaultLabel="Seleccionar permisos"
+                        display="chip"
+                        class="w-full"
+                    />
+                </div>
+            </div>
+
+            <div class="flex justify-end gap-3 pt-2">
+                <p-button type="button" label="Cancelar" icon="pi pi-times" text (click)="hideDialog()" />
+                <p-button type="submit" [label]="isEditMode ? 'Guardar cambios' : 'Crear rol'" icon="pi pi-check" />
+            </div>
+        </form>
+    </ng-template>
+</p-dialog>

--- a/src/app/pages/admin/roles/roles.scss
+++ b/src/app/pages/admin/roles/roles.scss
@@ -1,0 +1,11 @@
+:host {
+    display: block;
+}
+
+p-table {
+    width: 100%;
+}
+
+p-dialog ::ng-deep .p-dialog-content {
+    padding-top: 0;
+}

--- a/src/app/pages/admin/roles/roles.ts
+++ b/src/app/pages/admin/roles/roles.ts
@@ -1,0 +1,366 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, computed, signal } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
+import { TableLazyLoadEvent, TableModule } from 'primeng/table';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { DialogModule } from 'primeng/dialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { IconFieldModule } from 'primeng/iconfield';
+import { InputIconModule } from 'primeng/inputicon';
+import { Select } from 'primeng/select';
+import { MultiSelectModule } from 'primeng/multiselect';
+import { TagModule } from 'primeng/tag';
+import { TextareaModule } from 'primeng/textarea';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { Subject, debounceTime, distinctUntilChanged } from 'rxjs';
+import {
+    CreateRoleDto,
+    Role,
+    RoleFilters,
+    RolesService,
+    UpdateRoleDto
+} from '@/pages/service/roles.service';
+
+interface StatusOption {
+    label: string;
+    value: string;
+}
+
+interface PermissionOption {
+    label: string;
+    value: string;
+}
+
+@Component({
+    selector: 'app-roles',
+    standalone: true,
+    templateUrl: './roles.html',
+    styleUrl: './roles.scss',
+    imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        TableModule,
+        ButtonModule,
+        ToastModule,
+        ConfirmDialogModule,
+        DialogModule,
+        InputTextModule,
+        IconFieldModule,
+        InputIconModule,
+        Select,
+        MultiSelectModule,
+        TagModule,
+        TextareaModule
+    ],
+    providers: [MessageService, ConfirmationService]
+})
+export class RolesComponent implements OnInit {
+    readonly roles = signal<Role[]>([]);
+    readonly loading = signal(false);
+
+    readonly totalRecords = signal(0);
+    rows = 10;
+
+    readonly search$ = new Subject<string>();
+
+    readonly filtersForm: FormGroup;
+    readonly roleForm: FormGroup;
+
+    readonly statusOptions: StatusOption[] = [
+        { label: 'Todos', value: 'ALL' },
+        { label: 'Activo', value: 'ACT' },
+        { label: 'Inactivo', value: 'INA' },
+        { label: 'Bloqueado', value: 'BLO' }
+    ];
+
+    readonly statusSeverity = computed(() => ({
+        ACT: 'success',
+        INA: 'warning',
+        BLO: 'danger'
+    }));
+
+    permissionOptions: PermissionOption[] = [];
+
+    roleDialog = false;
+    isEditMode = false;
+    submitted = false;
+
+    private lastLazyEvent: TableLazyLoadEvent | null = null;
+    private selectedRole: Role | null = null;
+
+    constructor(
+        private readonly fb: FormBuilder,
+        private readonly rolesService: RolesService,
+        private readonly messageService: MessageService,
+        private readonly confirmationService: ConfirmationService,
+        private readonly router: Router
+    ) {
+        this.filtersForm = this.fb.group({
+            search: [''],
+            status: ['ALL']
+        });
+
+        this.roleForm = this.fb.group({
+            name: ['', Validators.required],
+            description: [''],
+            status: ['ACT', Validators.required],
+            permissions: [[] as string[]]
+        });
+
+        this.search$
+            .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed())
+            .subscribe(() => this.reloadRoles(true));
+
+        this.filtersForm
+            .get('search')!
+            .valueChanges.pipe(debounceTime(300), takeUntilDestroyed())
+            .subscribe((term) => this.search$.next((term as string) ?? ''));
+
+        this.filtersForm
+            .get('status')!
+            .valueChanges.pipe(takeUntilDestroyed())
+            .subscribe(() => this.reloadRoles(true));
+    }
+
+    ngOnInit(): void {
+        const initialEvent: TableLazyLoadEvent = { first: 0, rows: this.rows };
+        this.loadRoles(initialEvent);
+    }
+
+    loadRoles(event: TableLazyLoadEvent): void {
+        this.lastLazyEvent = { ...event };
+        const first = event.first ?? 0;
+        const rows = event.rows && event.rows > 0 ? event.rows : this.rows;
+        this.rows = rows;
+
+        const page = Math.floor(first / rows) + 1;
+        const limit = rows;
+
+        const filters: RoleFilters = {
+            search: (this.filtersForm.get('search')?.value ?? '').trim(),
+            status: this.filtersForm.get('status')?.value ?? 'ALL'
+        };
+
+        this.loading.set(true);
+
+        this.rolesService.findAll(page, limit, filters).subscribe({
+            next: (response) => {
+                this.roles.set(response.data);
+                this.totalRecords.set(response.total);
+                this.loading.set(false);
+                this.updatePermissionOptions(response.data);
+            },
+            error: () => {
+                this.loading.set(false);
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'No se pudieron cargar los roles',
+                    life: 3000
+                });
+            }
+        });
+    }
+
+    reloadRoles(resetPage = false): void {
+        if (resetPage && this.lastLazyEvent) {
+            this.lastLazyEvent = { ...this.lastLazyEvent, first: 0 };
+        }
+
+        if (this.lastLazyEvent) {
+            this.loadRoles(this.lastLazyEvent);
+        } else {
+            this.loadRoles({ first: 0, rows: this.rows });
+        }
+    }
+
+    openNew(): void {
+        this.roleDialog = true;
+        this.isEditMode = false;
+        this.submitted = false;
+        this.selectedRole = null;
+        this.resetForm();
+        this.roleForm.patchValue({ status: 'ACT', permissions: [] });
+    }
+
+    editRole(role: Role): void {
+        this.roleDialog = true;
+        this.isEditMode = true;
+        this.submitted = false;
+        this.selectedRole = role;
+        this.resetForm();
+        this.roleForm.patchValue({
+            name: role.name,
+            description: role.description ?? '',
+            status: role.status ?? 'ACT',
+            permissions: role.permissions ?? []
+        });
+    }
+
+    viewRole(role: Role): void {
+        const id = this.getRoleId(role);
+        if (id) {
+            this.router.navigate(['/complaints/roles', id]);
+        }
+    }
+
+    hideDialog(): void {
+        this.roleDialog = false;
+    }
+
+    saveRole(): void {
+        this.submitted = true;
+
+        if (this.roleForm.invalid) {
+            this.roleForm.markAllAsTouched();
+            return;
+        }
+
+        const { name, description, status, permissions } = this.roleForm.value;
+        const payload: CreateRoleDto | UpdateRoleDto = {
+            name: name!.trim(),
+            description: description?.trim() || undefined,
+            status: status ?? 'ACT',
+            permissions: permissions && permissions.length > 0 ? permissions : undefined
+        };
+
+        const roleId = this.getRoleId(this.selectedRole);
+
+        if (this.isEditMode && roleId) {
+            this.rolesService.update(roleId, payload).subscribe({
+                next: () => {
+                    this.messageService.add({
+                        severity: 'success',
+                        summary: 'Rol actualizado',
+                        detail: 'El rol se actualizó correctamente.',
+                        life: 3000
+                    });
+                    this.roleDialog = false;
+                    this.reloadRoles();
+                },
+                error: () =>
+                    this.messageService.add({
+                        severity: 'error',
+                        summary: 'Error',
+                        detail: 'No se pudo actualizar el rol.',
+                        life: 3000
+                    })
+            });
+            return;
+        }
+
+        this.rolesService.create(payload as CreateRoleDto).subscribe({
+            next: () => {
+                this.messageService.add({
+                    severity: 'success',
+                    summary: 'Rol creado',
+                    detail: 'El rol se creó correctamente.',
+                    life: 3000
+                });
+                this.roleDialog = false;
+                this.reloadRoles();
+            },
+            error: () =>
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'No se pudo crear el rol.',
+                    life: 3000
+                })
+        });
+    }
+
+    confirmDelete(role: Role): void {
+        this.confirmationService.confirm({
+            message: `¿Está seguro de eliminar el rol "${role.name}"?`,
+            header: 'Confirmar eliminación',
+            icon: 'pi pi-exclamation-triangle',
+            acceptLabel: 'Eliminar',
+            rejectLabel: 'Cancelar',
+            acceptButtonStyleClass: 'p-button-danger',
+            accept: () => this.deleteRole(role)
+        });
+    }
+
+    deleteRole(role: Role): void {
+        const roleId = this.getRoleId(role);
+        if (!roleId) {
+            return;
+        }
+
+        this.rolesService.remove(roleId).subscribe({
+            next: () => {
+                this.messageService.add({
+                    severity: 'success',
+                    summary: 'Rol eliminado',
+                    detail: 'El rol se marcó como inactivo.',
+                    life: 3000
+                });
+                this.reloadRoles();
+            },
+            error: () =>
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'No se pudo eliminar el rol.',
+                    life: 3000
+                })
+        });
+    }
+
+    getStatusLabel(status?: string): string {
+        switch (status) {
+            case 'ACT':
+                return 'Activo';
+            case 'INA':
+                return 'Inactivo';
+            case 'BLO':
+                return 'Bloqueado';
+            default:
+                return status ?? 'Desconocido';
+        }
+    }
+
+    getStatusSeverity(status?: string): string {
+        const severityMap = this.statusSeverity();
+        return severityMap[status as keyof typeof severityMap] ?? 'info';
+    }
+
+    isInvalid(controlName: string): boolean {
+        const control = this.roleForm.get(controlName);
+        return !!control && control.invalid && (control.dirty || control.touched || this.submitted);
+    }
+
+    private resetForm(): void {
+        this.roleForm.reset({
+            name: '',
+            description: '',
+            status: 'ACT',
+            permissions: []
+        });
+    }
+
+    private updatePermissionOptions(roles: Role[]): void {
+        const permissions = new Set<string>();
+        roles.forEach((role) => {
+            role.permissions?.forEach((permission) => permissions.add(permission));
+        });
+
+        this.permissionOptions = Array.from(permissions).map((permission) => ({
+            label: permission,
+            value: permission
+        }));
+    }
+
+    private getRoleId(role: Role | null | undefined): string | undefined {
+        if (!role) {
+            return undefined;
+        }
+
+        return role._id ?? role.id ?? undefined;
+    }
+}

--- a/src/app/pages/service/roles.service.ts
+++ b/src/app/pages/service/roles.service.ts
@@ -1,0 +1,76 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment';
+
+export interface Role {
+    _id?: string;
+    id?: string;
+    name: string;
+    description?: string;
+    status: 'ACT' | 'INA' | 'BLO' | string;
+    permissions?: string[];
+}
+
+export interface RoleFilters {
+    search?: string;
+    status?: string;
+}
+
+export interface PaginatedResponse<T> {
+    data: T[];
+    total: number;
+    page: number;
+    limit: number;
+}
+
+export interface CreateRoleDto {
+    name: string;
+    description?: string;
+    status?: Role['status'];
+    permissions?: string[];
+}
+
+export interface UpdateRoleDto {
+    name?: string;
+    description?: string;
+    status?: Role['status'];
+    permissions?: string[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class RolesService {
+    private readonly apiUrl = environment.backendUrl;
+    private readonly rolesEndpoint = `${this.apiUrl}/private/roles`;
+
+    constructor(private readonly http: HttpClient) {}
+
+    findAll(page: number = 1, limit: number = 10, filters?: RoleFilters) {
+        let params = new HttpParams().set('page', page).set('limit', limit);
+
+        if (filters?.search) {
+            params = params.set('search', filters.search.trim());
+        }
+
+        if (filters?.status && filters.status !== 'ALL') {
+            params = params.set('status', filters.status);
+        }
+
+        return this.http.get<PaginatedResponse<Role>>(this.rolesEndpoint, { params });
+    }
+
+    findOne(id: string) {
+        return this.http.get<Role>(`${this.rolesEndpoint}/${id}`);
+    }
+
+    create(dto: CreateRoleDto) {
+        return this.http.post<Role>(this.rolesEndpoint, dto);
+    }
+
+    update(id: string, dto: UpdateRoleDto) {
+        return this.http.patch<Role>(`${this.rolesEndpoint}/${id}`, dto);
+    }
+
+    remove(id: string) {
+        return this.http.delete<void>(`${this.rolesEndpoint}/${id}`);
+    }
+}


### PR DESCRIPTION
## Summary
- add a roles service to interact with the private roles API and expose typed DTOs
- implement a standalone roles management table with filters, CRUD dialog, and navigation entry
- introduce a role detail view and register new routes in the admin area

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/icon?family=Material+Icons returned status code: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d61a4244a8832bac646e18c9994b2b