### PR TITLE
feat: add reports excel download component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@angular/compiler": "^20",
                 "@angular/core": "^20",
                 "@angular/forms": "^20",
+                "@angular/material": "^20",
                 "@angular/google-maps": "^20.1.5",
                 "@angular/platform-browser": "^20",
                 "@angular/platform-browser-dynamic": "^20",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "@angular/compiler": "^20",
         "@angular/core": "^20",
         "@angular/forms": "^20",
+        "@angular/material": "^20",
         "@angular/google-maps": "^20.1.5",
         "@angular/platform-browser": "^20",
         "@angular/platform-browser-dynamic": "^20",

--- a/src/app.routes.ts
+++ b/src/app.routes.ts
@@ -6,6 +6,7 @@ import { FormComplaintsComponent } from '@/pages/form-complaints/form-complaints
 import { authGuard } from '@/guards/auth.guard';
 import { ViewComplaint } from '@/pages/view-complaint/view-complaint';
 import { HeatMapComponent } from '@/pages/admin/heat-map/heat-map.component';
+import { ReportsComponent } from '@/pages/reports/reports.component';
 
 export const appRoutes: Routes = [
     { path: '', component: FormComplaintsComponent },
@@ -16,6 +17,7 @@ export const appRoutes: Routes = [
         children: [
             { path: 'dashboard', component: DashboardComponent },
             { path: 'heat-map', data: { breadcrumb: 'Mapa de Calor' }, component: HeatMapComponent },
+            { path: 'reports', data: { breadcrumb: 'Reportes' }, component: ReportsComponent },
             { path: 'complaints', loadChildren: () => import('./app/pages/admin/admin.routes') },
             { path: 'uikit', loadChildren: () => import('./app/pages/uikit/uikit.routes') },
             { path: 'pages', loadChildren: () => import('./app/pages/pages.routes') }

--- a/src/app/layout/component/app.menu.ts
+++ b/src/app/layout/component/app.menu.ts
@@ -45,7 +45,7 @@ export class AppMenu {
             {
                 label: 'Reportes',
                 items: [
-
+                    { label: 'Descargas', icon: 'pi pi-download', routerLink: ['/reports'] }
                 ]
             },
 

--- a/src/app/pages/reports/reports.component.html
+++ b/src/app/pages/reports/reports.component.html
@@ -1,0 +1,48 @@
+<section class="reports-container">
+    <h1 class="reports-title">Descarga de reportes</h1>
+
+    <form [formGroup]="filtersForm" class="reports-form" novalidate>
+        <div class="form-grid">
+            <mat-form-field appearance="outline">
+                <mat-label>Fecha de inicio</mat-label>
+                <input matInput [matDatepicker]="startPicker" formControlName="startDate" placeholder="Seleccione una fecha" />
+                <mat-datepicker-toggle matIconSuffix [for]="startPicker"></mat-datepicker-toggle>
+                <mat-datepicker #startPicker></mat-datepicker>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+                <mat-label>Fecha de fin</mat-label>
+                <input matInput [matDatepicker]="endPicker" formControlName="endDate" placeholder="Seleccione una fecha" />
+                <mat-datepicker-toggle matIconSuffix [for]="endPicker"></mat-datepicker-toggle>
+                <mat-datepicker #endPicker></mat-datepicker>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+                <mat-label>Tipo de feedback</mat-label>
+                <mat-select formControlName="type">
+                    <mat-option [value]="null">Todos</mat-option>
+                    <mat-option *ngFor="let option of feedbackTypes" [value]="option.value">{{ option.label }}</mat-option>
+                </mat-select>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+                <mat-label>Estado</mat-label>
+                <mat-select formControlName="status">
+                    <mat-option [value]="null">Todos</mat-option>
+                    <mat-option *ngFor="let option of feedbackStatuses" [value]="option.value">{{ option.label }}</mat-option>
+                </mat-select>
+            </mat-form-field>
+        </div>
+    </form>
+
+    <div class="actions">
+        <button mat-raised-button color="primary" (click)="downloadFeedbacksReport()" [disabled]="isDownloadingGeneral">
+            {{ isDownloadingGeneral ? 'Descargando…' : 'Descargar listado general' }}
+        </button>
+        <button mat-stroked-button color="primary" (click)="downloadFeedbacksByCompanyReport()" [disabled]="isDownloadingByCompany">
+            {{ isDownloadingByCompany ? 'Descargando…' : 'Descargar por empresa' }}
+        </button>
+    </div>
+
+    <p class="error-message" *ngIf="errorMessage">{{ errorMessage }}</p>
+</section>

--- a/src/app/pages/reports/reports.component.scss
+++ b/src/app/pages/reports/reports.component.scss
@@ -1,0 +1,34 @@
+.reports-container {
+    max-width: 720px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.reports-title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.reports-form {
+    width: 100%;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.error-message {
+    color: #d32f2f;
+    margin: 0;
+}

--- a/src/app/pages/reports/reports.component.ts
+++ b/src/app/pages/reports/reports.component.ts
@@ -1,0 +1,141 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatNativeDateModule } from '@angular/material/core';
+import { finalize } from 'rxjs';
+import { FeedbackStatus, FeedbackType, ReportFilters, ReportsService } from '@/services/reports.service';
+
+interface FeedbackOption {
+    value: FeedbackType;
+    label: string;
+}
+
+interface StatusOption {
+    value: FeedbackStatus;
+    label: string;
+}
+
+type ReportsForm = FormGroup<{
+    startDate: FormControl<Date | null>;
+    endDate: FormControl<Date | null>;
+    type: FormControl<FeedbackType | null>;
+    status: FormControl<FeedbackStatus | null>;
+}>;
+
+@Component({
+    selector: 'app-reports',
+    standalone: true,
+    templateUrl: './reports.component.html',
+    styleUrl: './reports.component.scss',
+    imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatDatepickerModule,
+        MatNativeDateModule,
+        MatSelectModule,
+        MatButtonModule
+    ]
+})
+export class ReportsComponent {
+    private readonly fb = inject(FormBuilder);
+    private readonly reportsService = inject(ReportsService);
+
+    readonly filtersForm: ReportsForm = this.fb.group({
+        startDate: this.fb.control<Date | null>(null),
+        endDate: this.fb.control<Date | null>(null),
+        type: this.fb.control<FeedbackType | null>(null),
+        status: this.fb.control<FeedbackStatus | null>(null)
+    });
+
+    readonly feedbackTypes: FeedbackOption[] = [
+        { value: 'COMPLAINT', label: 'Queja' },
+        { value: 'SUGGESTION', label: 'Sugerencia' },
+        { value: 'CONGRATULATION', label: 'Felicitación' }
+    ];
+
+    readonly feedbackStatuses: StatusOption[] = [
+        { value: 'OPEN', label: 'Abierto' },
+        { value: 'IN_PROGRESS', label: 'En progreso' },
+        { value: 'RETURNED', label: 'Devuelto' },
+        { value: 'CLOSED', label: 'Cerrado' }
+    ];
+
+    isDownloadingGeneral = false;
+    isDownloadingByCompany = false;
+    errorMessage: string | null = null;
+
+    downloadFeedbacksReport(): void {
+        const filters = this.extractFilters();
+        this.errorMessage = null;
+        this.isDownloadingGeneral = true;
+
+        this.reportsService
+            .downloadFeedbacksReport(filters)
+            .pipe(finalize(() => (this.isDownloadingGeneral = false)))
+            .subscribe({
+                next: (blob) => this.saveBlob(blob, 'reporte-feedbacks.xlsx'),
+                error: (error) => {
+                    console.error('No se pudo descargar el reporte general de feedbacks', error);
+                    this.errorMessage = 'Ocurrió un error al descargar el listado general. Intente nuevamente.';
+                }
+            });
+    }
+
+    downloadFeedbacksByCompanyReport(): void {
+        const filters = this.extractFilters();
+        this.errorMessage = null;
+        this.isDownloadingByCompany = true;
+
+        this.reportsService
+            .downloadFeedbacksByCompanyReport(filters)
+            .pipe(finalize(() => (this.isDownloadingByCompany = false)))
+            .subscribe({
+                next: (blob) => this.saveBlob(blob, 'reporte-feedbacks-por-empresa.xlsx'),
+                error: (error) => {
+                    console.error('No se pudo descargar el reporte por empresa', error);
+                    this.errorMessage = 'Ocurrió un error al descargar el reporte por empresa. Intente nuevamente.';
+                }
+            });
+    }
+
+    private extractFilters(): ReportFilters {
+        const { startDate, endDate, type, status } = this.filtersForm.getRawValue();
+
+        const filters: ReportFilters = {};
+
+        if (startDate) {
+            filters.startDate = startDate;
+        }
+
+        if (endDate) {
+            filters.endDate = endDate;
+        }
+
+        if (type) {
+            filters.type = type;
+        }
+
+        if (status) {
+            filters.status = status;
+        }
+
+        return filters;
+    }
+
+    private saveBlob(blob: Blob, filename: string): void {
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = filename;
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+    }
+}

--- a/src/app/services/reports.service.ts
+++ b/src/app/services/reports.service.ts
@@ -1,0 +1,71 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export type FeedbackType = 'COMPLAINT' | 'SUGGESTION' | 'CONGRATULATION';
+export type FeedbackStatus = 'OPEN' | 'IN_PROGRESS' | 'RETURNED' | 'CLOSED';
+
+export interface ReportFilters {
+    startDate?: string | Date | null;
+    endDate?: string | Date | null;
+    type?: FeedbackType | null;
+    status?: FeedbackStatus | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ReportsService {
+    private readonly baseUrl = `${environment.backendUrl}/api/private/reports`;
+
+    constructor(private readonly http: HttpClient) {}
+
+    downloadFeedbacksReport(filters: ReportFilters): Observable<Blob> {
+        return this.http.get(`${this.baseUrl}/feedbacks/excel`, {
+            params: this.buildParams(filters),
+            responseType: 'blob'
+        });
+    }
+
+    downloadFeedbacksByCompanyReport(filters: ReportFilters): Observable<Blob> {
+        return this.http.get(`${this.baseUrl}/feedbacks-by-company/excel`, {
+            params: this.buildParams(filters),
+            responseType: 'blob'
+        });
+    }
+
+    private buildParams(filters: ReportFilters): HttpParams {
+        let params = new HttpParams();
+
+        if (!filters) {
+            return params;
+        }
+
+        const { startDate, endDate, type, status } = filters;
+
+        if (startDate) {
+            params = params.set('startDate', this.normalizeDateValue(startDate));
+        }
+
+        if (endDate) {
+            params = params.set('endDate', this.normalizeDateValue(endDate));
+        }
+
+        if (type) {
+            params = params.set('type', type);
+        }
+
+        if (status) {
+            params = params.set('status', status);
+        }
+
+        return params;
+    }
+
+    private normalizeDateValue(value: string | Date): string {
+        if (value instanceof Date) {
+            return value.toISOString();
+        }
+
+        return value;
+    }
+}


### PR DESCRIPTION
## Summary
- add Angular Material dependency to support material form inputs
- create a reports service and component that download Excel reports with filters
- register the new reports route and surface it from the sidebar menu

## Testing
- npm install *(fails: 403 Forbidden fetching @angular/material)*

------
https://chatgpt.com/codex/tasks/task_e_68d62732f97c832bae646781961a3fd7