### PR TITLE
feat: add reports downloads component

### DIFF
--- a/src/app/layout/component/app.menu.ts
+++ b/src/app/layout/component/app.menu.ts
@@ -45,7 +45,7 @@ export class AppMenu {
             {
                 label: 'Reportes',
                 items: [
-
+                    { label: 'Descargas', icon: 'pi pi-download', routerLink: ['/complaints/reports'] }
                 ]
             },
 

--- a/src/app/pages/admin/admin.routes.ts
+++ b/src/app/pages/admin/admin.routes.ts
@@ -9,6 +9,7 @@ import { RolesComponent } from './roles/roles';
 import { RoleDetailComponent } from './roles/role-detail';
 import { PermissionsComponent } from './permissions/permissions';
 import { PermissionDetailComponent } from './permissions/permission-detail';
+import { ReportsComponent } from './reports/reports.component';
 
 export default [
     { path: 'complaints', data: { breadcrumb: 'Quejas' }, component: Complaints },
@@ -20,6 +21,7 @@ export default [
     { path: 'permissions', data: { breadcrumb: 'Permisos' }, component: PermissionsComponent },
     { path: 'permissions/:id', data: { breadcrumb: 'Detalle de permiso' }, component: PermissionDetailComponent },
     { path: 'companies', data: { breadcrumb: 'Empresas' }, component: Companies },
+    { path: 'reports', data: { breadcrumb: 'Reportes' }, component: ReportsComponent },
     { path: 'menu', data: { breadcrumb: 'Menu' }, component: MenuDemo },
     /*{ path: 'button', data: { breadcrumb: 'Button' }, component: ButtonDemo },
     { path: 'charts', data: { breadcrumb: 'Charts' }, component: ChartDemo },

--- a/src/app/pages/admin/reports/reports.component.html
+++ b/src/app/pages/admin/reports/reports.component.html
@@ -1,54 +1,45 @@
-<section class="reports">
-    <h1>Reportes de feedback</h1>
+<div class="card shadow-2 mb-4 p-4">
+    <h2 class="text-2xl font-semibold mb-4">📊 Reportes de Feedback</h2>
 
-    <form [formGroup]="filtersForm" class="reports__form">
-        <div class="reports__fields">
-            <div class="reports__field">
-                <label for="startDate">Fecha de inicio</label>
-                <input id="startDate" type="date" formControlName="startDate" />
-            </div>
-            <div class="reports__field">
-                <label for="endDate">Fecha de fin</label>
-                <input id="endDate" type="date" formControlName="endDate" />
-            </div>
-            <div class="reports__field">
-                <label for="type">Tipo</label>
-                <select id="type" formControlName="type">
-                    <option [ngValue]="null">Todos</option>
-                    <option *ngFor="let option of typeOptions" [value]="option.value">{{ option.label }}</option>
-                </select>
-            </div>
-            <div class="reports__field">
-                <label for="status">Estado</label>
-                <select id="status" formControlName="status">
-                    <option [ngValue]="null">Todos</option>
-                    <option *ngFor="let option of statusOptions" [value]="option.value">{{ option.label }}</option>
-                </select>
-            </div>
-        </div>
+    <form [formGroup]="filtersForm" class="grid formgrid">
+        <!-- Fecha inicio -->
+        <div class="reports__field"> <label for="startDate"><b>Fecha de inicio: </b></label> <input id="startDate" type="date"
+                formControlName="startDate" /> </div>
+        <!-- Fecha Fin -->
+        <div class="reports__field"> <label for="endDate"><b>Fecha de fin: </b></label> <input id="endDate" type="date"
+                formControlName="endDate" /> </div>
 
-        <p class="reports__error" *ngIf="isDateRangeInvalid">
-            La fecha de inicio no puede ser mayor que la fecha de fin.
-        </p>
 
-        <div class="reports__actions">
-            <button
-                pButton
-                type="button"
-                label="Descargar listado general"
-                icon="pi pi-download"
-                (click)="downloadFeedbacksReport()"
-                [disabled]="isDownloadingFeedbacks || isDateRangeInvalid"
-            ></button>
+            <!-- Tipo -->
+            <div class="col-12 md:col-6 field">
+                <label for="type" class="font-medium">Tipo</label>
+                <p-select id="type" [options]="typeOptions" formControlName="type" optionLabel="label"
+                    optionValue="value" placeholder="Todos" showClear="true" styleClass="w-full"></p-select>
+            </div>
 
-            <button
-                pButton
-                type="button"
-                label="Descargar por empresa"
-                icon="pi pi-building"
-                (click)="downloadFeedbacksByCompanyReport()"
-                [disabled]="isDownloadingByCompany || isDateRangeInvalid"
-            ></button>
-        </div>
+            <!-- Estado -->
+            <div class="col-12 md:col-6 field">
+                <label for="status" class="font-medium">Estado</label>
+                <p-select id="status" [options]="statusOptions" formControlName="status" optionLabel="label"
+                    optionValue="value" placeholder="Todos" showClear="true" styleClass="w-full"></p-select>
+            </div>
+
+            <!-- Error fechas -->
+            <div class="col-12" *ngIf="isDateRangeInvalid">
+                <small class="p-error block">
+                    ⚠️ La fecha de inicio no puede ser mayor que la fecha de fin.
+                </small>
+            </div>
+
+            <!-- Acciones -->
+            <div class="col-12 flex justify-content-end gap-3 mt-4">
+                <button pButton type="button" label="Listado general" icon="pi pi-download" class="p-button-primary"
+                    (click)="downloadFeedbacksReport()"
+                    [disabled]="isDownloadingFeedbacks || isDateRangeInvalid"></button>
+
+                <button pButton type="button" label="Por empresa" icon="pi pi-building" class="p-button-success"
+                    (click)="downloadFeedbacksByCompanyReport()"
+                    [disabled]="isDownloadingByCompany || isDateRangeInvalid"></button>
+            </div>
     </form>
-</section>
+</div>

--- a/src/app/pages/admin/reports/reports.component.html
+++ b/src/app/pages/admin/reports/reports.component.html
@@ -1,0 +1,54 @@
+<section class="reports">
+    <h1>Reportes de feedback</h1>
+
+    <form [formGroup]="filtersForm" class="reports__form">
+        <div class="reports__fields">
+            <div class="reports__field">
+                <label for="startDate">Fecha de inicio</label>
+                <input id="startDate" type="date" formControlName="startDate" />
+            </div>
+            <div class="reports__field">
+                <label for="endDate">Fecha de fin</label>
+                <input id="endDate" type="date" formControlName="endDate" />
+            </div>
+            <div class="reports__field">
+                <label for="type">Tipo</label>
+                <select id="type" formControlName="type">
+                    <option [ngValue]="null">Todos</option>
+                    <option *ngFor="let option of typeOptions" [value]="option.value">{{ option.label }}</option>
+                </select>
+            </div>
+            <div class="reports__field">
+                <label for="status">Estado</label>
+                <select id="status" formControlName="status">
+                    <option [ngValue]="null">Todos</option>
+                    <option *ngFor="let option of statusOptions" [value]="option.value">{{ option.label }}</option>
+                </select>
+            </div>
+        </div>
+
+        <p class="reports__error" *ngIf="isDateRangeInvalid">
+            La fecha de inicio no puede ser mayor que la fecha de fin.
+        </p>
+
+        <div class="reports__actions">
+            <button
+                pButton
+                type="button"
+                label="Descargar listado general"
+                icon="pi pi-download"
+                (click)="downloadFeedbacksReport()"
+                [disabled]="isDownloadingFeedbacks || isDateRangeInvalid"
+            ></button>
+
+            <button
+                pButton
+                type="button"
+                label="Descargar por empresa"
+                icon="pi pi-building"
+                (click)="downloadFeedbacksByCompanyReport()"
+                [disabled]="isDownloadingByCompany || isDateRangeInvalid"
+            ></button>
+        </div>
+    </form>
+</section>

--- a/src/app/pages/admin/reports/reports.component.ts
+++ b/src/app/pages/admin/reports/reports.component.ts
@@ -1,0 +1,116 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { finalize } from 'rxjs';
+import { FeedbackReportStatus, FeedbackReportType, ReportsFilters, ReportsService } from '@/services/reports.service';
+
+interface SelectOption<T> {
+    label: string;
+    value: T;
+}
+
+@Component({
+    selector: 'app-reports',
+    standalone: true,
+    imports: [CommonModule, ReactiveFormsModule, ButtonModule],
+    templateUrl: './reports.component.html'
+})
+export class ReportsComponent {
+    private readonly reportsService = inject(ReportsService);
+    private readonly formBuilder = inject(FormBuilder);
+
+    readonly typeOptions: SelectOption<FeedbackReportType>[] = [
+        { label: 'Quejas', value: 'COMPLAINT' },
+        { label: 'Sugerencias', value: 'SUGGESTION' },
+        { label: 'Felicitaciones', value: 'CONGRATULATION' }
+    ];
+
+    readonly statusOptions: SelectOption<FeedbackReportStatus>[] = [
+        { label: 'Abierto', value: 'OPEN' },
+        { label: 'En progreso', value: 'IN_PROGRESS' },
+        { label: 'Devuelto', value: 'RETURNED' },
+        { label: 'Cerrado', value: 'CLOSED' }
+    ];
+
+    readonly filtersForm: FormGroup = this.formBuilder.group({
+        startDate: [null],
+        endDate: [null],
+        type: [null],
+        status: [null]
+    });
+
+    isDownloadingFeedbacks = false;
+    isDownloadingByCompany = false;
+
+    get isDateRangeInvalid(): boolean {
+        const start = this.filtersForm.get('startDate')?.value;
+        const end = this.filtersForm.get('endDate')?.value;
+
+        if (!start || !end) {
+            return false;
+        }
+
+        const startDate = new Date(start);
+        const endDate = new Date(end);
+
+        return !isNaN(startDate.getTime()) && !isNaN(endDate.getTime()) && startDate > endDate;
+    }
+
+    downloadFeedbacksReport(): void {
+        if (this.isDateRangeInvalid) {
+            return;
+        }
+
+        this.isDownloadingFeedbacks = true;
+        const filters = this.getFilters();
+
+        this.reportsService
+            .downloadFeedbacksReport(filters)
+            .pipe(finalize(() => (this.isDownloadingFeedbacks = false)))
+            .subscribe({
+                next: (blob) => this.saveFile(blob, 'reporte-feedbacks.xlsx'),
+                error: (error) => console.error('Error al descargar el reporte de feedbacks', error)
+            });
+    }
+
+    downloadFeedbacksByCompanyReport(): void {
+        if (this.isDateRangeInvalid) {
+            return;
+        }
+
+        this.isDownloadingByCompany = true;
+        const filters = this.getFilters();
+
+        this.reportsService
+            .downloadFeedbacksByCompanyReport(filters)
+            .pipe(finalize(() => (this.isDownloadingByCompany = false)))
+            .subscribe({
+                next: (blob) => this.saveFile(blob, 'reporte-feedbacks-por-empresa.xlsx'),
+                error: (error) => console.error('Error al descargar el reporte por empresa', error)
+            });
+    }
+
+    private getFilters(): ReportsFilters {
+        const { startDate, endDate, type, status } = this.filtersForm.value;
+
+        return {
+            startDate: startDate ? new Date(startDate) : null,
+            endDate: endDate ? new Date(endDate) : null,
+            type: type ?? null,
+            status: status ?? null
+        };
+    }
+
+    private saveFile(blob: Blob, filename: string): void {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        link.rel = 'noopener';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+}

--- a/src/app/pages/admin/reports/reports.component.ts
+++ b/src/app/pages/admin/reports/reports.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { finalize } from 'rxjs';
 import { FeedbackReportStatus, FeedbackReportType, ReportsFilters, ReportsService } from '@/services/reports.service';
+import { Select } from 'primeng/select';
 
 interface SelectOption<T> {
     label: string;
@@ -13,7 +14,7 @@ interface SelectOption<T> {
 @Component({
     selector: 'app-reports',
     standalone: true,
-    imports: [CommonModule, ReactiveFormsModule, ButtonModule],
+    imports: [CommonModule, ReactiveFormsModule, ButtonModule, Select],
     templateUrl: './reports.component.html'
 })
 export class ReportsComponent {
@@ -21,16 +22,18 @@ export class ReportsComponent {
     private readonly formBuilder = inject(FormBuilder);
 
     readonly typeOptions: SelectOption<FeedbackReportType>[] = [
-        { label: 'Quejas', value: 'COMPLAINT' },
-        { label: 'Sugerencias', value: 'SUGGESTION' },
-        { label: 'Felicitaciones', value: 'CONGRATULATION' }
+         { label: 'Queja', value: 'complaint' },
+        { label: 'Sugerencia', value: 'suggestion' },
+        { label: 'Felicitación', value: 'compliment' }
     ];
 
     readonly statusOptions: SelectOption<FeedbackReportStatus>[] = [
-        { label: 'Abierto', value: 'OPEN' },
-        { label: 'En progreso', value: 'IN_PROGRESS' },
-        { label: 'Devuelto', value: 'RETURNED' },
-        { label: 'Cerrado', value: 'CLOSED' }
+        { value: 'PENDING', label: 'Pendiente' },
+        { value: 'RESOLVED', label: 'Resuelto' },
+        { value: 'IN_PROGRESS', label: 'En progreso' },
+        { value: 'RETURNED', label: 'Devuelto' },
+        { value: 'FORWARDED', label: 'Derivado' },
+        { value: 'CANCEL', label: 'Cancelado' }
     ];
 
     readonly filtersForm: FormGroup = this.formBuilder.group({

--- a/src/app/services/reports.service.ts
+++ b/src/app/services/reports.service.ts
@@ -1,0 +1,67 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment';
+
+export type FeedbackReportType = 'COMPLAINT' | 'SUGGESTION' | 'CONGRATULATION';
+export type FeedbackReportStatus = 'OPEN' | 'IN_PROGRESS' | 'RETURNED' | 'CLOSED';
+
+export interface ReportsFilters {
+    startDate?: Date | string | null;
+    endDate?: Date | string | null;
+    type?: FeedbackReportType | null;
+    status?: FeedbackReportStatus | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ReportsService {
+    private readonly baseUrl = `${environment.backendUrl}/api/private/reports`;
+
+    constructor(private http: HttpClient) {}
+
+    downloadFeedbacksReport(filters: ReportsFilters) {
+        const params = this.buildParams(filters);
+        return this.http.get(`${this.baseUrl}/feedbacks/excel`, {
+            params,
+            responseType: 'blob'
+        });
+    }
+
+    downloadFeedbacksByCompanyReport(filters: ReportsFilters) {
+        const params = this.buildParams(filters);
+        return this.http.get(`${this.baseUrl}/feedbacks-by-company/excel`, {
+            params,
+            responseType: 'blob'
+        });
+    }
+
+    private buildParams(filters: ReportsFilters): HttpParams {
+        let params = new HttpParams();
+
+        if (filters.startDate) {
+            params = params.set('startDate', this.toIsoString(filters.startDate));
+        }
+
+        if (filters.endDate) {
+            params = params.set('endDate', this.toIsoString(filters.endDate));
+        }
+
+        if (filters.type) {
+            params = params.set('type', filters.type);
+        }
+
+        if (filters.status) {
+            params = params.set('status', filters.status);
+        }
+
+        return params;
+    }
+
+    private toIsoString(value: Date | string): string {
+        if (value instanceof Date) {
+            return value.toISOString();
+        }
+
+        const parsed = new Date(value);
+        return isNaN(parsed.getTime()) ? value : parsed.toISOString();
+    }
+}

--- a/src/app/services/reports.service.ts
+++ b/src/app/services/reports.service.ts
@@ -2,8 +2,8 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 
-export type FeedbackReportType = 'COMPLAINT' | 'SUGGESTION' | 'CONGRATULATION';
-export type FeedbackReportStatus = 'OPEN' | 'IN_PROGRESS' | 'RETURNED' | 'CLOSED';
+export type FeedbackReportType = 'complaint' | 'suggestion' | 'compliment';
+export type FeedbackReportStatus = 'PENDING' | 'IN_PROGRESS' | 'RESOLVED' | 'RETURNED' | 'FORWARDED' | 'CANCEL';
 
 export interface ReportsFilters {
     startDate?: Date | string | null;
@@ -14,7 +14,7 @@ export interface ReportsFilters {
 
 @Injectable({ providedIn: 'root' })
 export class ReportsService {
-    private readonly baseUrl = `${environment.backendUrl}/api/private/reports`;
+    private readonly baseUrl = `${environment.backendUrl}/private/reports`;
 
     constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- add a reports service that calls the Excel export endpoints with optional filters
- create a standalone ReportsComponent with a reactive form and download actions for the two report types
- expose the new reports page through the admin routes and sidebar menu

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d629221d24832b86e1a82a27c3723c