### PR TITLE
Implement role-based menu visibility for configuration options

### DIFF
--- a/src/app/layout/component/app.menu.ts
+++ b/src/app/layout/component/app.menu.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { MenuItem } from 'primeng/api';
 import { AppMenuitem } from './app.menuitem';
+import { AuthService } from '@/services/auth.service';
 
 @Component({
     selector: 'app-menu',
@@ -15,31 +16,56 @@ import { AppMenuitem } from './app.menuitem';
         </ng-container>
     </ul> `
 })
-export class AppMenu {
+export class AppMenu implements OnInit {
     model: MenuItem[] = [];
 
-    ngOnInit() {
-        this.model = [
+    private readonly authService = inject(AuthService);
+
+    ngOnInit(): void {
+        const baseMenu: MenuItem[] = [
             {
                 label: 'Inicio',
-                items: [{ label: 'Dashboard', icon: 'pi pi-fw pi-home', routerLink: ['/dashboard'] },
-                { label: 'Mapa de Calor', icon: 'pi pi-fw pi-map', routerLink: ['/heat-map'] }]
+                items: [
+                    { label: 'Dashboard', icon: 'pi pi-fw pi-home', routerLink: ['/dashboard'] },
+                    { label: 'Mapa de Calor', icon: 'pi pi-fw pi-map', routerLink: ['/heat-map'] }
+                ]
             },
             {
                 label: 'Administración',
                 items: [
                     { label: 'Quejas', icon: 'pi pi-exclamation-triangle', routerLink: ['/complaints/complaints'] },
                     { label: 'Sugerencias', icon: 'pi pi-lightbulb', routerLink: ['/complaints/suggestions'] },
-                    { label: 'Felicitaciones', icon: 'pi pi-heart', routerLink: ['/complaints/congratulations'] },
+                    { label: 'Felicitaciones', icon: 'pi pi-heart', routerLink: ['/complaints/congratulations'] }
                 ]
             },
             {
                 label: 'Configuración',
+                data: { roles: ['ADMIN'] },
                 items: [
-                    { label: 'Usuarios', icon: 'pi pi-fw pi-users', routerLink: ['/complaints/users'] },
-                    { label: 'Roles', icon: 'pi pi-id-card', routerLink: ['/complaints/roles'] },
-                    { label: 'Permisos', icon: 'pi pi-shield', routerLink: ['/complaints/permissions'] },
-                    { label: 'Empresas', icon: 'pi pi-fw pi-briefcase', routerLink: ['/complaints/companies'] },
+                    {
+                        label: 'Usuarios',
+                        icon: 'pi pi-fw pi-users',
+                        routerLink: ['/complaints/users'],
+                        data: { roles: ['ADMIN'] }
+                    },
+                    {
+                        label: 'Roles',
+                        icon: 'pi pi-id-card',
+                        routerLink: ['/complaints/roles'],
+                        data: { roles: ['ADMIN'] }
+                    },
+                    {
+                        label: 'Permisos',
+                        icon: 'pi pi-shield',
+                        routerLink: ['/complaints/permissions'],
+                        data: { roles: ['ADMIN'] }
+                    },
+                    {
+                        label: 'Empresas',
+                        icon: 'pi pi-fw pi-briefcase',
+                        routerLink: ['/complaints/companies'],
+                        data: { roles: ['ADMIN'] }
+                    }
                 ]
             },
             {
@@ -47,8 +73,41 @@ export class AppMenu {
                 items: [
                     { label: 'Descargas', icon: 'pi pi-download', routerLink: ['/complaints/reports'] }
                 ]
-            },
-
+            }
         ];
+
+        this.model = this.applyRoleVisibility(baseMenu);
+    }
+
+    private applyRoleVisibility(menu: MenuItem[]): MenuItem[] {
+        return menu
+            .map(item => {
+                const itemCopy: MenuItem = { ...item };
+
+                const requiredRoles = this.extractRoles(itemCopy);
+                if (requiredRoles.length > 0 && !this.authService.hasRole(requiredRoles)) {
+                    itemCopy.visible = false;
+                }
+
+                if (itemCopy.items) {
+                    itemCopy.items = this.applyRoleVisibility(itemCopy.items);
+                    if ((itemCopy.items?.length ?? 0) === 0 && !itemCopy.routerLink) {
+                        itemCopy.visible = false;
+                    }
+                }
+
+                return itemCopy;
+            })
+            .filter(item => item.visible !== false);
+    }
+
+    private extractRoles(item: MenuItem): string[] {
+        const metadata = item['data'] as { roles?: string[] } | undefined;
+
+        if (!metadata?.roles) {
+            return [];
+        }
+
+        return metadata.roles.filter((role): role is string => typeof role === 'string');
     }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -4,6 +4,12 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, map, tap } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
+interface JwtPayload {
+    role?: string;
+    roles?: string[];
+    [key: string]: unknown;
+}
+
 @Injectable({ providedIn: 'root' })
 export class AuthService {
 
@@ -31,6 +37,67 @@ export class AuthService {
     }
 
     isAuthenticated(): boolean {
-        return !!localStorage.getItem('token');
+        return !!this.getToken();
+    }
+
+    getToken(): string | null {
+        return localStorage.getItem('token');
+    }
+
+    getUserRoles(): string[] {
+        const payload = this.getTokenPayload();
+
+        if (!payload) {
+            return [];
+        }
+
+        if (typeof payload.role === 'string') {
+            return [payload.role];
+        }
+
+        if (Array.isArray(payload.roles)) {
+            return payload.roles.filter((role): role is string => typeof role === 'string');
+        }
+
+        return [];
+    }
+
+    hasRole(requiredRoles: string | string[]): boolean {
+        const rolesToCheck = Array.isArray(requiredRoles) ? requiredRoles : [requiredRoles];
+        const userRoles = this.getUserRoles();
+
+        if (rolesToCheck.length === 0) {
+            return true;
+        }
+
+        return rolesToCheck.some(role => userRoles.includes(role));
+    }
+
+    private getTokenPayload(): JwtPayload | null {
+        const token = this.getToken();
+
+        if (!token) {
+            return null;
+        }
+
+        const [, payload] = token.split('.');
+
+        if (!payload) {
+            return null;
+        }
+
+        try {
+            const decoded = this.base64UrlDecode(payload);
+            return JSON.parse(decoded) as JwtPayload;
+        } catch (error) {
+            console.error('Failed to parse token payload', error);
+            return null;
+        }
+    }
+
+    private base64UrlDecode(value: string): string {
+        const normalizedValue = value.replace(/-/g, '+').replace(/_/g, '/');
+        const paddedValue = normalizedValue.padEnd(normalizedValue.length + (4 - (normalizedValue.length % 4)) % 4, '=');
+        return atob(paddedValue);
     }
 }


### PR DESCRIPTION
## Summary
- decode JWT payloads in the auth service to expose helper methods for retrieving roles
- apply role-based visibility when building the main menu, hiding configuration entries for non-admin users

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/icon?family=Material+Icons returned status code: 403.)*


------
https://chatgpt.com/codex/tasks/task_e_68da43301aa4832b9dd1a3631814ed75